### PR TITLE
Feature/spec errors

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -20,7 +20,7 @@ type Backend interface {
 
 	BucketExists(name string) (exists bool, err error)
 
-	// DeleteBucket deletes a bucket iff it is empty.
+	// DeleteBucket deletes a bucket if and only if it is empty.
 	//
 	// If the bucket is not empty, gofakes3.ResourceError with
 	// gofakes3.ErrBucketNotEmpty MUST be returned.

--- a/backend.go
+++ b/backend.go
@@ -34,6 +34,18 @@ type Backend interface {
 	// See gofakes3.KeyNotFound() for a convenient way to create one.
 	GetObject(bucketName, objectName string) (*Object, error)
 
+	// DeleteObject deletes an object from the bucket.
+	//
+	// DeleteObject must return a gofakes3.ErrNoSuchBucket error if the bucket
+	// does not exist. See gofakes3.BucketNotFound() for a convenient way to create one.
+	//
+	// DeleteObject must not return an error if the object does not exist. Source:
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.DeleteObject:
+	//
+	//	Removes the null version (if there is one) of an object and inserts a
+	//	delete marker, which becomes the latest version of the object. If there
+	//	isn't a null version, Amazon S3 does not remove any objects.
+	//
 	DeleteObject(bucketName, objectName string) error
 
 	// HeadObject fetches the Object from the backend, but the Contents will be

--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -59,7 +59,7 @@ func run() error {
 		return fmt.Errorf("unknown backend %q", backend)
 	}
 
-	if err := back.CreateBucket(bucket); err != nil && !gofakes3.IsErrExist(err) {
+	if err := back.CreateBucket(bucket); err != nil && !gofakes3.IsAlreadyExists(err) {
 		return fmt.Errorf("gofakes3: could not create initial bucket %q: %v", bucket, err)
 	}
 

--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -59,8 +59,8 @@ func run() error {
 		return fmt.Errorf("unknown backend %q", backend)
 	}
 
-	if err := back.CreateBucket(bucket); err != nil {
-		return err
+	if err := back.CreateBucket(bucket); err != nil && !gofakes3.IsErrExist(err) {
+		return fmt.Errorf("gofakes3: could not create initial bucket %q: %v", bucket, err)
 	}
 
 	log.Println("created bucket", bucket)

--- a/cors.go
+++ b/cors.go
@@ -1,0 +1,38 @@
+package gofakes3
+
+import (
+	"log"
+	"net/http"
+	"regexp"
+
+	"github.com/gorilla/mux"
+)
+
+type WithCORS struct {
+	r *mux.Router
+}
+
+func (s *WithCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, HEAD")
+	w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-Amz-User-Agent, X-Amz-Date, x-amz-meta-from, x-amz-meta-to, x-amz-meta-filename, x-amz-meta-private")
+
+	if r.Method == "OPTIONS" {
+		return
+	}
+	// Bucket name rewriting
+	// this is due to some inconsistencies in the AWS SDKs
+	re := regexp.MustCompile("(127.0.0.1:\\d{1,7})|(.localhost:\\d{1,7})|(localhost:\\d{1,7})")
+	bucket := re.ReplaceAllString(r.Host, "")
+	if len(bucket) > 0 {
+		log.Println("rewrite bucket ->", bucket)
+		p := r.URL.Path
+		r.URL.Path = "/" + bucket
+		if p != "/" {
+			r.URL.Path += p
+		}
+	}
+	log.Println("=>", r.URL)
+
+	s.r.ServeHTTP(w, r)
+}

--- a/error.go
+++ b/error.go
@@ -1,20 +1,185 @@
 package gofakes3
 
-import "fmt"
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+)
 
-type errNotFound struct {
-	bucket, object string
+const (
+	ErrBucketAlreadyExists ErrorCode = "BucketAlreadyExists"
+
+	// Raised when attempting to delete a bucket that still contains items.
+	ErrBucketNotEmpty ErrorCode = "BucketNotEmpty"
+
+	// You did not provide the number of bytes specified by the Content-Length
+	// HTTP header:
+	ErrIncompleteBody ErrorCode = "IncompleteBody"
+
+	// https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
+	ErrInvalidBucketName ErrorCode = "InvalidBucketName"
+
+	ErrKeyTooLong       ErrorCode = "KeyTooLongError"
+	ErrMetadataTooLarge ErrorCode = "MetadataTooLarge"
+	ErrMethodNotAllowed ErrorCode = "MethodNotAllowed"
+	ErrMalformedXML     ErrorCode = "MalformedXML"
+
+	// See BucketNotFound() for a helper function for this error:
+	ErrNoSuchBucket ErrorCode = "NoSuchBucket"
+
+	// See KeyNotFound() for a helper function for this error:
+	ErrNoSuchKey ErrorCode = "NoSuchKey"
+
+	ErrRequestTimeTooSkewed ErrorCode = "RequestTimeTooSkewed"
+	ErrTooManyBuckets       ErrorCode = "TooManyBuckets"
+	ErrNotImplemented       ErrorCode = "NotImplemented"
+
+	ErrInternal ErrorCode = "InternalError"
+)
+
+type Error interface {
+	error
+	Code() ErrorCode
+	Message() string
 }
 
-func (e *errNotFound) Error() string {
-	return fmt.Sprintf("gofakes3: not found: bucket %q, object %q", e.bucket, e.object)
+type ErrorResponse struct {
+	XMLName xml.Name `xml:"Error"`
+
+	Code      ErrorCode
+	Message   string `xml:",omitempty"`
+	Resource  string `xml:",omitempty"`
+	RequestID string `xml:"RequestId,omitempty"`
 }
 
-func IsNotFound(err error) bool {
-	_, ok := err.(*errNotFound)
-	return ok
+func NewErrorResponse(err error, requestID string) ErrorResponse {
+	s3err, ok := err.(Error)
+	if !ok {
+		return ErrorResponse{
+			Code:      ErrInternal,
+			Message:   "Internal Error",
+			RequestID: requestID,
+		}
+	}
+
+	resp := ErrorResponse{
+		Code:      s3err.Code(),
+		Message:   s3err.Message(),
+		RequestID: requestID,
+	}
+	if resp.Message == "" {
+		resp.Message = s3err.Code().Message()
+	}
+	if rerr, ok := err.(interface{ Resource() string }); ok {
+		resp.Resource = rerr.Resource()
+	}
+
+	return resp
 }
 
-func NotFound(bucket, object string) error {
-	return &errNotFound{bucket: bucket, object: object}
+func ResourceError(code ErrorCode, resource string) error {
+	return &resourceError{
+		code:     code,
+		resource: resource,
+	}
+}
+
+func ErrorMessage(code ErrorCode, message string) error {
+	return &messageError{
+		code:    code,
+		message: message,
+	}
+}
+
+func BucketNotFound(bucket string) error {
+	return &resourceError{code: ErrNoSuchBucket, resource: bucket}
+}
+
+func KeyNotFound(key string) error {
+	return &resourceError{code: ErrNoSuchKey, resource: key}
+}
+
+type ErrorCode string
+
+var _ Error = ErrorCode("")
+
+func (e ErrorCode) Error() string   { return string(e) }
+func (e ErrorCode) Code() ErrorCode { return e }
+
+func (e ErrorCode) Message() string {
+	switch e {
+	case ErrNoSuchBucket:
+		return "The specified bucket does not exist"
+	case ErrRequestTimeTooSkewed:
+		return "The difference between the request time and the current time is too large"
+	default:
+		return ""
+	}
+}
+
+func (e ErrorCode) Status() int {
+	switch e {
+	case ErrBucketAlreadyExists,
+		ErrBucketNotEmpty:
+		return http.StatusConflict
+
+	case ErrIncompleteBody,
+		ErrInvalidBucketName,
+		ErrKeyTooLong,
+		ErrMetadataTooLarge,
+		ErrMethodNotAllowed,
+		ErrMalformedXML,
+		ErrTooManyBuckets:
+		return http.StatusBadRequest
+
+	case ErrRequestTimeTooSkewed:
+		return http.StatusForbidden
+
+	case ErrNoSuchBucket,
+		ErrNoSuchKey:
+		return http.StatusNotFound
+
+	case ErrNotImplemented:
+		return http.StatusNotImplemented
+
+	case ErrInternal:
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusInternalServerError
+}
+
+type resourceError struct {
+	code     ErrorCode
+	resource string // The bucket or object that is involved in the error.
+}
+
+var _ Error = &resourceError{}
+
+func (re *resourceError) Code() ErrorCode  { return re.code }
+func (re *resourceError) Error() string    { return fmt.Sprintf("%s: %s", re.code, re.resource) }
+func (re *resourceError) Message() string  { return "" }
+func (re *resourceError) Resource() string { return re.resource }
+
+type messageError struct {
+	code    ErrorCode
+	message string
+}
+
+var _ Error = &messageError{}
+
+func (re *messageError) Code() ErrorCode { return re.code }
+func (re *messageError) Error() string   { return fmt.Sprintf("%s: %s", re.code, re.message) }
+func (re *messageError) Message() string { return re.message }
+
+func HasErrorCode(err error, code ErrorCode) bool {
+	s3err, ok := err.(Error)
+	if !ok {
+		return false
+	}
+	return s3err.Code() == code
+}
+
+func IsErrExist(err error) bool {
+	return HasErrorCode(err, ErrBucketAlreadyExists)
 }

--- a/error.go
+++ b/error.go
@@ -13,6 +13,8 @@ import (
 // If you add a code to this list, please also add it to ErrorCode.Status().
 //
 const (
+	ErrNone ErrorCode = ""
+
 	ErrBucketAlreadyExists ErrorCode = "BucketAlreadyExists"
 
 	// Raised when attempting to delete a bucket that still contains items.
@@ -183,7 +185,12 @@ func (e ErrorCode) Status() int {
 //		// handle condition
 //	}
 //
+// If err is nil and code is ErrNone, HasErrorCode returns true.
+//
 func HasErrorCode(err error, code ErrorCode) bool {
+	if err == nil && code == "" {
+		return true
+	}
 	s3err, ok := err.(interface{ ErrorCode() ErrorCode })
 	if !ok {
 		return false

--- a/error.go
+++ b/error.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+// Error codes are documented here:
+// https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+//
+// If you add a code to this list, please also add it to ErrorCode.Status().
+//
 const (
 	ErrBucketAlreadyExists ErrorCode = "BucketAlreadyExists"
 
@@ -38,28 +43,17 @@ const (
 	ErrInternal ErrorCode = "InternalError"
 )
 
-type Error interface {
-	error
-	ErrorCode() ErrorCode
-}
-
+// errorResponse should be implemented by any type that needs to be handled by
+// ensureErrorResponse.
 type errorResponse interface {
 	Error
-	Enrich(requestID string)
-}
-
-type ErrorResponse struct {
-	XMLName xml.Name `xml:"Error"`
-
-	Code      ErrorCode
-	Message   string `xml:",omitempty"`
-	RequestID string `xml:"RequestId,omitempty"`
+	enrich(requestID string)
 }
 
 func ensureErrorResponse(err error, requestID string) Error {
 	switch err := err.(type) {
 	case errorResponse:
-		err.Enrich(requestID)
+		err.enrich(requestID)
 		return err
 
 	case ErrorCode:
@@ -78,25 +72,68 @@ func ensureErrorResponse(err error, requestID string) Error {
 	}
 }
 
-func (e *ErrorResponse) ErrorCode() ErrorCode { return e.Code }
-
-func (r *ErrorResponse) Enrich(requestID string) {
-	r.RequestID = requestID
+type Error interface {
+	error
+	ErrorCode() ErrorCode
 }
+
+// ErrorResponse is the base error type returned by S3 when any error occurs.
+//
+// Some errors contain their own additional fields in the response, for example
+// ErrRequestTimeTooSkewed, which contains the server time and the skew limit.
+// To create one of these responses, subclass it (but please don't export it):
+//
+//	type notQuiteRightResponse struct {
+//		ErrorResponse
+//		ExtraField int
+//	}
+//
+// Next, create a constructor that populates the error. Interfaces won't work
+// for this job as the error itself does double-duty as the XML response
+// object. Fill the struct out however you please, but don't forget to assign
+// Code and Message:
+//
+//	func NotQuiteRight(at time.Time, max time.Duration) error {
+// 	    code := ErrNotQuiteRight
+// 	    return &notQuiteRightResponse{
+// 	        ErrorResponse{Code: code, Message: code.Message()},
+// 	        123456789,
+// 	    }
+// 	}
+//
+type ErrorResponse struct {
+	XMLName xml.Name `xml:"Error"`
+
+	Code      ErrorCode
+	Message   string `xml:",omitempty"`
+	RequestID string `xml:"RequestId,omitempty"`
+}
+
+func (e *ErrorResponse) ErrorCode() ErrorCode { return e.Code }
 
 func (e *ErrorResponse) Error() string {
 	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func (r *ErrorResponse) enrich(requestID string) {
+	r.RequestID = requestID
 }
 
 func ErrorMessage(code ErrorCode, message string) error {
 	return &ErrorResponse{Code: code, Message: message}
 }
 
+// ErrorCode represents an S3 error code, documented here:
+// https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 type ErrorCode string
 
 func (e ErrorCode) ErrorCode() ErrorCode { return e }
 func (e ErrorCode) Error() string        { return string(e) }
 
+// Message tries to return the same string as S3 would return for the error
+// response, when it is known, or nothing when it is not. If you see the status
+// text for a code we don't have listed in here in the wild, please let us
+// know!
 func (e ErrorCode) Message() string {
 	switch e {
 	case ErrNoSuchBucket:
@@ -140,6 +177,12 @@ func (e ErrorCode) Status() int {
 	return http.StatusInternalServerError
 }
 
+// HasErrorCode asserts that the error has a specific error code:
+//
+//	if HasErrorCode(err, ErrNoSuchBucket) {
+//		// handle condition
+//	}
+//
 func HasErrorCode(err error, code ErrorCode) bool {
 	s3err, ok := err.(interface{ ErrorCode() ErrorCode })
 	if !ok {
@@ -148,7 +191,9 @@ func HasErrorCode(err error, code ErrorCode) bool {
 	return s3err.ErrorCode() == code
 }
 
-func IsErrExist(err error) bool {
+// IsAlreadyExists asserts that the error is a kind that indicates the resource
+// already exists, similar to os.IsExist.
+func IsAlreadyExists(err error) bool {
 	return HasErrorCode(err, ErrBucketAlreadyExists)
 }
 
@@ -185,6 +230,8 @@ func requestTimeTooSkewed(at time.Time, max time.Duration) error {
 	}
 }
 
+// durationAsMilliseconds tricks xml.Marsha into serialising a time.Duration as
+// truncated milliseconds instead of nanoseconds.
 type durationAsMilliseconds time.Duration
 
 func (m durationAsMilliseconds) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,28 @@
+package gofakes3
+
+import (
+	"encoding/xml"
+	"testing"
+	"time"
+)
+
+func TestErrorCustomResponseMarshalsAsExpected(t *testing.T) {
+	resp := requestTimeTooSkewed(time.Time{}, 123)
+	out, err := xml.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This is slightly brittle, but it does ensure that the embedded struct
+	// has its fields merged with the element rather than being nested:
+	expected := `<Error>` +
+		`<Code>RequestTimeTooSkewed</Code>` +
+		`<Message>The difference between the request time and the current time is too large</Message>` +
+		`<ServerTime>0001-01-01T00:00:00Z</ServerTime>` +
+		`<MaxAllowedSkewMilliseconds>0</MaxAllowedSkewMilliseconds>` +
+		`</Error>`
+
+	if string(out) != expected {
+		t.Fatalf("expected:\n%s\nfound:\n%s", expected, out)
+	}
+}

--- a/messages.go
+++ b/messages.go
@@ -1,0 +1,59 @@
+package gofakes3
+
+import (
+	"encoding/xml"
+	"io"
+	"time"
+)
+
+type Storage struct {
+	XMLName     xml.Name     `xml:"ListAllMyBucketsResult"`
+	Xmlns       string       `xml:"xmlns,attr"`
+	Id          string       `xml:"Owner>ID"`
+	DisplayName string       `xml:"Owner>DisplayName"`
+	Buckets     []BucketInfo `xml:"Buckets"`
+}
+
+type BucketInfo struct {
+	Name         string `xml:"Bucket>Name"`
+	CreationDate string `xml:"Bucket>CreationDate"`
+}
+
+type Content struct {
+	Key          string      `xml:"Key"`
+	LastModified ContentTime `xml:"LastModified"`
+	ETag         string      `xml:"ETag"`
+	Size         int         `xml:"Size"`
+	StorageClass string      `xml:"StorageClass"`
+}
+
+type ContentTime time.Time
+
+func (c ContentTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	// This is the format expected by the aws xml code, not the default.
+	var s = time.Time(c).Format("2006-01-02T15:04:05Z")
+	return e.EncodeElement(s, start)
+}
+
+type Bucket struct {
+	XMLName  xml.Name   `xml:"ListBucketResult"`
+	Xmlns    string     `xml:"xmlns,attr"`
+	Name     string     `xml:"Name"`
+	Prefix   string     `xml:"Prefix"`
+	Marker   string     `xml:"Marker"`
+	Contents []*Content `xml:"Contents"`
+}
+
+func NewBucket(name string) *Bucket {
+	return &Bucket{
+		Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Name:  name,
+	}
+}
+
+type Object struct {
+	Metadata map[string]string
+	Size     int64
+	Contents io.ReadCloser
+	Hash     []byte
+}

--- a/option.go
+++ b/option.go
@@ -1,0 +1,28 @@
+package gofakes3
+
+import "time"
+
+type Option func(g *GoFakeS3)
+
+func WithTimeSource(timeSource TimeSource) Option {
+	return func(g *GoFakeS3) { g.timeSource = timeSource }
+}
+
+// WithTimeSkewLimit allows you to reconfigure the allowed skew between the
+// client's clock and the server's clock. The AWS client SDKs will send the
+// "x-amz-date" header containing the time at the client, which is used to
+// calculate the skew.
+//
+// See DefaultSkewLimit for the starting value, set to '0' to disable.
+//
+func WithTimeSkewLimit(skew time.Duration) Option {
+	return func(g *GoFakeS3) { g.timeSkew = skew }
+}
+
+// WithMetadataSizeLimit allows you to reconfigure the maximum allowed metadata
+// size.
+//
+// See DefaultMetadataSizeLimit for the starting value, set to '0' to disable.
+func WithMetadataSizeLimit(size int) Option {
+	return func(g *GoFakeS3) { g.metadataSizeLimit = size }
+}

--- a/time.go
+++ b/time.go
@@ -4,6 +4,7 @@ import "time"
 
 type TimeSource interface {
 	Now() time.Time
+	Since(time.Time) time.Duration
 }
 
 func DefaultTimeSource() TimeSource {
@@ -22,4 +23,8 @@ type locatedTimeSource struct {
 
 func (l *locatedTimeSource) Now() time.Time {
 	return time.Now().In(l.timeLocation)
+}
+
+func (l *locatedTimeSource) Since(t time.Time) time.Duration {
+	return time.Since(t)
 }

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,49 @@
+package gofakes3
+
+import (
+	"net"
+	"regexp"
+	"strings"
+)
+
+// This pattern can be used to match both the entire bucket name (including period-
+// separated labels) and the individual label components, presuming you have already
+// split the string by period.
+var bucketNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9\.-]+)[a-z0-9]$`)
+
+// ValidateBucketName applies the rules from the AWS docs:
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
+//
+// 1. Bucket names must comply with DNS naming conventions.
+// 2. Bucket names must be at least 3 and no more than 63 characters long.
+// 3. Bucket names must not contain uppercase characters or underscores.
+// 4. Bucket names must start with a lowercase letter or number.
+//
+// The DNS RFC confirms that the valid range of characters in an LDH label is 'a-z0-9-':
+// https://tools.ietf.org/html/rfc5890#section-2.3.1
+//
+func ValidateBucketName(name string) error {
+	if len(name) < 3 || len(name) > 63 {
+		return ErrorMessage(ErrInvalidBucketName, "bucket name must be >= 3 characters and <= 63")
+	}
+	if !bucketNamePattern.MatchString(name) {
+		return ErrorMessage(ErrInvalidBucketName, "bucket must start and end with 'a-z, 0-9', and contain only 'a-z, 0-9, -' in between")
+	}
+
+	if net.ParseIP(name) != nil {
+		return ErrorMessage(ErrInvalidBucketName, "bucket names must not be formatted as an IP address")
+	}
+
+	// Bucket names must be a series of one or more labels. Adjacent labels are
+	// separated by a single period (.). Bucket names can contain lowercase
+	// letters, numbers, and hyphens. Each label must start and end with a
+	// lowercase letter or a number.
+	labels := strings.Split(name, ".")
+	for _, label := range labels {
+		if !bucketNamePattern.MatchString(label) {
+			return ErrorMessage(ErrInvalidBucketName, "label must start and end with 'a-z, 0-9', and contain only 'a-z, 0-9, -' in between")
+		}
+	}
+
+	return nil
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,69 @@
+package gofakes3
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestValidateBucketName(t *testing.T) {
+	type tcase struct {
+		name    string
+		errCode ErrorCode
+	}
+
+	baseCases := []tcase{
+		{"", ErrInvalidBucketName},
+
+		// This is not in nameCases because appending labels to it will cause an error:
+		{strings.Repeat("1", 63), ErrNone},
+
+		// Appending labels to these causes them to pass:
+		{"192.168.1.1", ErrInvalidBucketName},     // IP addresses are not allowed as bucket names. These may trip the "3-char min" rule first.
+		{"192.168.111.111", ErrInvalidBucketName}, // These should not trip the 3-char min but should still fail.
+	}
+
+	nameCases := []tcase{
+		{"yep", ErrNone},
+		{"0yep", ErrNone},
+		{"yep0", ErrNone},
+		{"y-p", ErrNone},
+		{"y--p", ErrNone},
+
+		{"NUP", ErrInvalidBucketName},
+		{"n🤡p", ErrInvalidBucketName}, // UTF-8 is effectively invalid because the high bytes fall outside the legal range
+		{"-nup", ErrInvalidBucketName},
+		{"nup-", ErrInvalidBucketName},
+		{"-nup-", ErrInvalidBucketName},
+
+		{"1", ErrInvalidBucketName},  // Too short
+		{"12", ErrInvalidBucketName}, // Too short
+		{"123", ErrNone},
+		{strings.Repeat("1", 64), ErrInvalidBucketName},
+	}
+
+	// All the same rules that apply to names apply to "labels" (the "."-separated
+	// portions of a bucket name, like DNS):
+	var labelCases []tcase
+	for _, tc := range nameCases {
+		labelCases = append(labelCases, []tcase{
+			{name: fmt.Sprintf("%s.label", tc.name), errCode: tc.errCode},
+			{name: fmt.Sprintf("label.%s", tc.name), errCode: tc.errCode},
+			{name: fmt.Sprintf("label.%s.label", tc.name), errCode: tc.errCode},
+		}...)
+	}
+
+	var cases []tcase
+	cases = append(cases, baseCases...)
+	cases = append(cases, nameCases...)
+	cases = append(cases, labelCases...)
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			err := ValidateBucketName(tc.name)
+			if !HasErrorCode(err, tc.errCode) {
+				t.Fatalf("name %q did not contain code %q", tc.name, tc.errCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hello again! Thank you for inviting me to collaborate. I have really enjoyed working on the code here so far, it has been very easy to work with.

This PR is another structural one, and once again it is a somewhat deep change. It adds support for backends to return rich errors that reflect the XML structure S3 returns. I've used a few tricks to pull that off; the errors returned are actually the same serialisable values the XML marshaller will return to the client!

You can also, in a pinch, just return ErrorCode directly as the HTTP handler will turn it into an XML response just the same. It's this design decision I'm a bit less certain of but it was convenient enough in practice and helped with the refactoring of the existing backends. I am just a bit more concerned it might give Backend authors license to leave out too much information. Maybe it can evolve over time to the helper constructor style, like `BucketNotFound()` and friends, then we can remove this quirk of ErrorCodes. What do you think?

There are a lot of extra errors implemented here than the core ones that the backends needed to support the basic functionality. I did this in order to try to put the design decisions I had made to the test to make sure I had laid enough groundwork to cover future changes. Things like "RequestTimeTooSkewed" really didn't need to be implemented from a usability point of view (I didn't even realise that was a thing AWS would fail on!), but it was very useful as a driver to help get the shape and behaviour of the derived response types right (and it can't hurt to have a few extra checks around!) You can see from the commit history that it took me a few goes, and that doesn't include the failed attempts that never got committed in the first place 😆 