### PR TITLE
Feature/prefix handling retry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
     - image: circleci/golang:1.9
-    working_directory: ~/go/src/github.com/johannesboyne/gofakes3
+    working_directory: /go/src/github.com/johannesboyne/gofakes3
     steps:
     - checkout
     - run: go get -v -t -d ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
     - image: circleci/golang:1.9
-    working_directory: ~/github.com/johannesboyne/gofakes3
+    working_directory: ~/go/src/github.com/johannesboyne/gofakes3
     steps:
     - checkout
     - run: go get -v -t -d ./...

--- a/README.md
+++ b/README.md
@@ -40,16 +40,36 @@ We're using it for the local development of S3 dependent Lambda functions and to
 
 ## How to use it?
 
-Please feel free to check it out and to provide useful feedback (using github issues), but be aware, this software is used internally and for the local development only. Thus, it has no demand for correctness, performance or security.
+Please feel free to check it out and to provide useful feedback (using github
+issues), but be aware, this software is used internally and for the local
+development only. Thus, it has no demand for correctness, performance or
+security.
 
-**For setting it up locally, you'll have to do the following:**
+There are two ways to run locally: using DNS, or using S3 path mode.
 
-- add the following to your `/etc/hosts`: `127.0.0.1 <bucket-name>.localhost`
-- start the gofakes3 service, e.g.: `./s3f_darwin_amd64 -db tests3.db -port ":9000"`
+S3 path mode is the most flexible and least restrictive, but it does require that you
+are able to modify your client code.In Go, the modification would look like so:
+    
+	config := aws.Config{}
+	config.WithS3ForcePathStyle(true)
 
-### Exemplary usage
+S3 path mode works over the network by default for all bucket names.
 
-#### Lambda Example
+If you are unable to modify the code, DNS mode can be used, but it comes with further
+restrictions and requires you to be able to modify your local DNS resolution.
+
+If using `localhost` as your endpoint, you will need to add the following to
+`/etc/hosts` for *every bucket you want to fake*:
+
+    127.0.0.1 <bucket-name>.localhost
+
+It is trickier if you want other machines to be able to use your fake S3 server
+as you need to be able to modify their DNS resolution as well.
+
+
+## Exemplary usage
+
+### Lambda Example
 
 ```javascript
 var AWS   = require('aws-sdk')
@@ -67,7 +87,7 @@ exports.handle = function (e, ctx) {
 }
 ```
 
-#### Upload Example
+### Upload Example
 
 ```html
 <html>

--- a/awscli_test.go
+++ b/awscli_test.go
@@ -1,0 +1,230 @@
+package gofakes3_test
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johannesboyne/gofakes3"
+)
+
+func TestCLILsBuckets(t *testing.T) {
+	ts := newTestServer(t, withoutInitialBuckets())
+	defer ts.Close()
+	cli := testCLI{ts}
+
+	if len(cli.lsBuckets()) != 0 {
+		t.Fatal()
+	}
+
+	ts.createBucket("foo")
+	if !reflect.DeepEqual(cli.lsBuckets().Names(), []string{"foo"}) {
+		t.Fatal()
+	}
+
+	ts.createBucket("bar")
+	if !reflect.DeepEqual(cli.lsBuckets().Names(), []string{"bar", "foo"}) {
+		t.Fatal()
+	}
+}
+
+func TestCLILsFiles(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	cli := testCLI{ts}
+
+	if len(cli.lsFiles(defaultBucket, "")) != 0 {
+		t.Fatal()
+	}
+
+	ts.putString(defaultBucket, "test-one", nil, "hello")
+	cli.assertLsFiles(defaultBucket, "",
+		nil, []string{"test-one"})
+
+	ts.putString(defaultBucket, "test-two", nil, "hello")
+	cli.assertLsFiles(defaultBucket, "",
+		nil, []string{"test-one", "test-two"})
+
+	// only "test-one" and "test-two" should pass the prefix match
+	ts.putString(defaultBucket, "no-match", nil, "hello")
+	cli.assertLsFiles(defaultBucket, "test-",
+		nil, []string{"test-one", "test-two"})
+
+	ts.putString(defaultBucket, "test/yep", nil, "hello")
+	cli.assertLsFiles(defaultBucket, "",
+		[]string{"test/"}, []string{"no-match", "test-one", "test-two"})
+
+	// "test-one" and "test-two" and the directory "test" should pass the prefix match:
+	cli.assertLsFiles(defaultBucket, "test",
+		[]string{"test/"}, []string{"test-one", "test-two"})
+
+	// listing with a trailing slash should list the directory contents:
+	cli.assertLsFiles(defaultBucket, "test/",
+		nil, []string{"yep"})
+}
+
+type testCLI struct {
+	*testServer
+}
+
+func (tc *testCLI) command(method string, args ...string) *exec.Cmd {
+	tc.Helper()
+
+	if method != "s3" && method != "s3api" {
+		panic("expected 's3' or 's3api'")
+	}
+
+	cmdArgs := append([]string{
+		"--output", "json",
+		method,
+		"--endpoint", tc.server.URL,
+	}, args...)
+
+	cmd := exec.Command("aws", cmdArgs...)
+	cmd.Env = []string{
+		"AWS_ACCESS_KEY_ID=key",
+		"AWS_SECRET_ACCESS_KEY=secret",
+	}
+	return cmd
+}
+
+func (tc *testCLI) combinedOutput(method string, args ...string) (out []byte) {
+	tc.Helper()
+	out, err := tc.command(method, args...).CombinedOutput()
+	if _, ok := err.(*exec.Error); ok {
+		tc.Skip("aws cli not found on $PATH")
+	}
+	tc.OK(err)
+	return out
+}
+
+var cliLsDirMatcher = regexp.MustCompile(`^\s*PRE (.*)$`)
+
+func (tc *testCLI) assertLsFiles(bucket string, prefix string, dirs []string, files []string) (items cliLsItems) {
+	tc.TT.Helper()
+	items = tc.lsFiles(bucket, prefix)
+	items.assertContents(tc.TT, dirs, files)
+	return items
+}
+
+func (tc *testCLI) lsFiles(bucket string, prefix string) (items cliLsItems) {
+	tc.Helper()
+
+	prefix = strings.TrimLeft(prefix, "/")
+	out := tc.combinedOutput("s3", "ls", fmt.Sprintf("s3://%s/%s", bucket, prefix))
+
+	scn := bufio.NewScanner(bytes.NewReader(out))
+	for scn.Scan() {
+		cur := scn.Text()
+		dir := cliLsDirMatcher.FindStringSubmatch(cur)
+		if dir != nil {
+			items = append(items, cliLsItem{
+				isDir: true,
+				name:  dir[1], // first submatch
+			})
+
+		} else { // file matching
+			var ct cliTime
+			var item cliLsItem
+			tc.OKAll(fmt.Sscan(scn.Text(), &ct, &item.size, &item.name))
+			item.date = time.Time(ct)
+			items = append(items, item)
+		}
+	}
+
+	return items
+}
+
+func (tc *testCLI) lsBuckets() (buckets gofakes3.Buckets) {
+	tc.Helper()
+
+	out := tc.combinedOutput("s3", "ls")
+
+	scn := bufio.NewScanner(bytes.NewReader(out))
+	for scn.Scan() {
+		var ct cliTime
+		var b gofakes3.BucketInfo
+		tc.OKAll(fmt.Sscan(scn.Text(), &ct, &b.Name))
+		b.CreationDate = ct.contentTime()
+		buckets = append(buckets, b)
+	}
+
+	return buckets
+}
+
+type cliLsItems []cliLsItem
+
+func (cl cliLsItems) assertContents(tt gofakes3.TT, dirs []string, files []string) {
+	tt.Helper()
+	cl.assertFiles(tt, files...)
+	cl.assertDirs(tt, dirs...)
+}
+
+func (cl cliLsItems) assertDirs(tt gofakes3.TT, names ...string) {
+	tt.Helper()
+	cl.assertItems(tt, true, names...)
+}
+
+func (cl cliLsItems) assertFiles(tt gofakes3.TT, names ...string) {
+	tt.Helper()
+	cl.assertItems(tt, false, names...)
+}
+
+func (cl cliLsItems) assertItems(tt gofakes3.TT, isDir bool, names ...string) {
+	tt.Helper()
+	var found []string
+	for _, item := range cl {
+		if item.isDir == isDir {
+			found = append(found, item.name)
+		}
+	}
+	sort.Strings(found)
+	sort.Strings(names)
+	if !reflect.DeepEqual(found, names) {
+		tt.Fatalf("items:\nexp: %v\ngot: %v", names, found)
+	}
+}
+
+type cliLsItem struct {
+	name  string
+	date  time.Time
+	size  int
+	isDir bool
+}
+
+type cliTime time.Time
+
+func (c cliTime) contentTime() gofakes3.ContentTime {
+	return gofakes3.NewContentTime(time.Time(c))
+}
+
+func (c *cliTime) Scan(state fmt.ScanState, verb rune) error {
+	d, err := state.Token(false, nil)
+	if err != nil {
+		return err
+	}
+	ds := string(d)
+
+	t, err := state.Token(true, nil)
+	if err != nil {
+		return err
+	}
+	ts := string(t)
+
+	// CLI returns time in the machine's timezone:
+	tv, err := time.ParseInLocation("2006-01-01 15:04:05", ds+" "+ts, time.Local)
+	if err != nil {
+		return err
+	}
+
+	*c = cliTime(tv.In(time.UTC))
+
+	return nil
+}

--- a/backend.go
+++ b/backend.go
@@ -11,6 +11,9 @@ import (
 // is likely until this notice is removed.
 //
 type Backend interface {
+	// ListBuckets returns a list of all buckets owned by the authenticated
+	// sender of the request.
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
 	ListBuckets() ([]BucketInfo, error)
 
 	// GetBucket returns the contents of a bucket. Backends should use the

--- a/backend.go
+++ b/backend.go
@@ -4,12 +4,22 @@ import (
 	"io"
 )
 
+// Backend provides a set of operations to be implemented in order to support
+// gofakes3.
+//
+// The Backend API is not yet stable; if you create your own Backend, breakage
+// is likely until this notice is removed.
+//
 type Backend interface {
 	ListBuckets() ([]BucketInfo, error)
 
+	// GetBucket returns the contents of a bucket. Backends should use the
+	// supplied prefix to limit the contents of the bucket and to sort the
+	// matched items into the Contents and CommonPrefixes fields.
+	//
 	// GetBucket must return a gofakes3.ErrNoSuchBucket error if the bucket
 	// does not exist. See gofakes3.BucketNotFound() for a convenient way to create one.
-	GetBucket(name string) (*Bucket, error)
+	GetBucket(name string, prefix Prefix) (*Bucket, error)
 
 	// CreateBucket creates the bucket if it does not already exist. The name
 	// should be assumed to be a valid name.

--- a/backend.go
+++ b/backend.go
@@ -69,5 +69,6 @@ type Backend interface {
 	HeadObject(bucketName, objectName string) (*Object, error)
 
 	// PutObject should assume that the key is valid.
+	// meta may be nil.
 	PutObject(bucketName, key string, meta map[string]string, input io.Reader) error
 }

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -91,9 +91,8 @@ func (db *Backend) GetBucket(name string, prefix gofakes3.Prefix) (*gofakes3.Buc
 				item := &gofakes3.Content{
 					Key:          string(k),
 					LastModified: mod,
-					ETag:         "\"" + hex.EncodeToString(hash[:]) + "\"",
+					ETag:         `"` + hex.EncodeToString(hash[:]) + `"`,
 					Size:         len(v),
-					StorageClass: "STANDARD",
 				}
 				bucket.Add(item)
 			}

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -192,13 +192,13 @@ func (db *Backend) CreateBucket(name string) error {
 }
 
 func (db *Backend) DeleteBucket(name string) error {
+	nameBts := []byte(name)
+
+	if bytes.Equal(nameBts, db.metaBucketName) {
+		return gofakes3.ResourceError(gofakes3.ErrInvalidBucketName, name)
+	}
+
 	return db.bolt.Update(func(tx *bolt.Tx) error {
-		nameBts := []byte(name)
-
-		if bytes.Equal(nameBts, db.metaBucketName) {
-			panic("gofakes3: attempted to delete metadata bucket")
-		}
-
 		{ // delete bucket
 			b := tx.Bucket(nameBts)
 			if b == nil {

--- a/backend/s3bolt/schema.go
+++ b/backend/s3bolt/schema.go
@@ -1,0 +1,79 @@
+package s3bolt
+
+// The schema for the bolt database is described in here. External users of the
+// database should consider this an internal implementation detail, subject to
+// change without notice or version number changes.
+//
+// This may change in the future.
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/johannesboyne/gofakes3"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type boltBucket struct {
+	CreationDate time.Time
+}
+
+type boltObject struct {
+	Metadata     map[string]string
+	LastModified time.Time
+	Size         int64
+	Contents     []byte
+	Hash         []byte
+}
+
+func (b *boltObject) Object() *gofakes3.Object {
+	return &gofakes3.Object{
+		Metadata: b.Metadata,
+		Size:     b.Size,
+		Contents: readerWithDummyCloser{bytes.NewReader(b.Contents)},
+		Hash:     b.Hash,
+	}
+}
+
+func bucketMetaKey(name string) []byte {
+	return []byte("bucket/" + name)
+}
+
+type metaBucket struct {
+	*bolt.Tx
+	metaName []byte
+	bucket   *bolt.Bucket
+}
+
+func (mb *metaBucket) deleteS3Bucket(bucket string) error {
+	return mb.bucket.Delete(bucketMetaKey(bucket))
+}
+
+func (mb *metaBucket) createS3Bucket(bucket string, at time.Time) error {
+	bb := &boltBucket{
+		CreationDate: at,
+	}
+	data, err := bson.Marshal(bb)
+	if err != nil {
+		return err
+	}
+	if err := mb.bucket.Put(bucketMetaKey(bucket), data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (mb *metaBucket) s3Bucket(bucket string) (*boltBucket, error) {
+	bts := mb.bucket.Get(bucketMetaKey(bucket))
+	if bts == nil {
+		// FIXME: should return an error once database upgrades are supported.
+		return nil, nil
+	}
+
+	var bb boltBucket
+	if err := bson.Unmarshal(bts, &bb); err != nil {
+		return nil, err
+	}
+	return &bb, nil
+}

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -75,7 +75,7 @@ func (db *Backend) GetBucket(name string, prefix gofakes3.Prefix) (*gofakes3.Buc
 			response.Add(&gofakes3.Content{
 				Key:          item.key,
 				LastModified: gofakes3.ContentTime(item.lastModified),
-				ETag:         "\"" + hex.EncodeToString(item.hash) + "\"",
+				ETag:         `"` + hex.EncodeToString(item.hash) + `"`,
 				Size:         len(item.data),
 			})
 		}

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -45,8 +45,8 @@ func (db *Backend) ListBuckets() ([]gofakes3.BucketInfo, error) {
 	var buckets = make([]gofakes3.BucketInfo, 0, len(db.buckets))
 	for _, bucket := range db.buckets {
 		buckets = append(buckets, gofakes3.BucketInfo{
-			Name: bucket.name,
-			// CreationDate: bucket.creationDate,
+			Name:         bucket.name,
+			CreationDate: bucket.creationDate,
 		})
 	}
 
@@ -74,7 +74,7 @@ func (db *Backend) GetBucket(name string, prefix gofakes3.Prefix) (*gofakes3.Buc
 		} else {
 			response.Add(&gofakes3.Content{
 				Key:          item.key,
-				LastModified: gofakes3.ContentTime(item.lastModified),
+				LastModified: gofakes3.NewContentTime(item.lastModified),
 				ETag:         `"` + hex.EncodeToString(item.hash) + `"`,
 				Size:         len(item.data),
 			})
@@ -93,8 +93,9 @@ func (db *Backend) CreateBucket(name string) error {
 	}
 
 	db.buckets[name] = &bucket{
-		name: name,
-		data: map[string]*bucketItem{},
+		name:         name,
+		creationDate: gofakes3.NewContentTime(db.timeSource.Now()),
+		data:         map[string]*bucketItem{},
 	}
 	return nil
 }

--- a/backend/s3mem/bucket.go
+++ b/backend/s3mem/bucket.go
@@ -1,6 +1,10 @@
 package s3mem
 
-import "time"
+import (
+	"time"
+
+	"github.com/johannesboyne/gofakes3"
+)
 
 type bucketItem struct {
 	key          string
@@ -11,6 +15,7 @@ type bucketItem struct {
 }
 
 type bucket struct {
-	name string
-	data map[string]*bucketItem
+	name         string
+	creationDate gofakes3.ContentTime
+	data         map[string]*bucketItem
 }

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -150,26 +150,16 @@ func (g *GoFakeS3) GetBucket(w http.ResponseWriter, r *http.Request) {
 	log.Println("GET BUCKET")
 	vars := mux.Vars(r)
 	bucketName := vars["BucketName"]
-	prefix := r.URL.Query().Get("prefix")
+
+	prefix := prefixFromQuery(r.URL.Query())
 
 	log.Println("bucketname:", bucketName)
 	log.Println("prefix    :", prefix)
 
-	bucket, err := g.storage.GetBucket(bucketName)
+	bucket, err := g.storage.GetBucket(bucketName, prefix)
 	if err != nil {
 		g.httpError(w, r, err)
 		return
-	}
-
-	if prefix != "" {
-		idx := 0
-		for _, entry := range bucket.Contents {
-			if strings.Contains(entry.Key, prefix) {
-				bucket.Contents[idx] = entry
-				idx++
-			}
-		}
-		bucket.Contents = bucket.Contents[:idx]
 	}
 
 	x, err := xml.MarshalIndent(bucket, "", "  ")

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -3,7 +3,11 @@ package gofakes3_test
 import (
 	"bytes"
 	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -13,51 +17,101 @@ import (
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 )
 
-type TT struct {
-	*testing.T
+const defaultBucket = "mybucket"
+
+var defaultDate = time.Date(2018, 1, 1, 12, 0, 0, 0, time.UTC)
+
+type testServer struct {
+	gofakes3.TT
+	gofakes3.TimeSourceAdvancer
+	*gofakes3.GoFakeS3
+
+	backend gofakes3.Backend
+	server  *httptest.Server
+
+	// if this is nil, no buckets are created. by default, a starting bucket is
+	// created using the value of the 'defaultBucket' constant.
+	initialBuckets []string
 }
 
-func (t TT) OK(err error) {
+type testServerOption func(ts *testServer)
+
+func withoutInitialBuckets() testServerOption { return func(ts *testServer) { ts.initialBuckets = nil } }
+func withInitialBuckets(buckets ...string) testServerOption {
+	return func(ts *testServer) { ts.initialBuckets = buckets }
+}
+
+func newTestServer(t *testing.T, opts ...testServerOption) *testServer {
 	t.Helper()
-	if err != nil {
-		t.Fatal(err)
+	var ts = testServer{
+		TT:             gofakes3.TT{t},
+		initialBuckets: []string{defaultBucket},
 	}
-}
+	for _, o := range opts {
+		o(&ts)
+	}
 
-func (t TT) OKAll(vs ...interface{}) {
-	t.Helper()
-	for _, v := range vs {
-		if err, ok := v.(error); ok && err != nil {
-			t.Fatal(err)
+	if ts.backend == nil {
+		if ts.TimeSourceAdvancer == nil {
+			ts.TimeSourceAdvancer = gofakes3.FixedTimeSource(defaultDate)
 		}
+		ts.backend = s3mem.New(s3mem.WithTimeSource(ts.TimeSourceAdvancer))
 	}
+
+	ts.GoFakeS3 = gofakes3.New(ts.backend,
+		gofakes3.WithTimeSource(ts.TimeSourceAdvancer),
+		gofakes3.WithTimeSkewLimit(0),
+	)
+	ts.server = httptest.NewServer(ts.GoFakeS3.Server())
+
+	for _, bucket := range ts.initialBuckets {
+		ts.TT.OK(ts.backend.CreateBucket(bucket))
+	}
+
+	return &ts
+}
+
+func (ts *testServer) createBucket(bucket string) {
+	ts.Helper()
+	if err := ts.backend.CreateBucket(bucket); err != nil {
+		ts.Fatal("create bucket failed", err)
+	}
+}
+
+func (ts *testServer) putString(bucket, key string, meta map[string]string, in string) {
+	ts.Helper()
+	ts.OK(ts.backend.PutObject(bucket, key, meta, strings.NewReader(in)))
+}
+
+func (ts *testServer) client() *s3.S3 {
+	config := aws.NewConfig()
+	config.WithEndpoint(ts.server.URL)
+	config.WithRegion("region")
+	config.WithCredentials(credentials.NewStaticCredentials("dummy-access", "dummy-secret", ""))
+	config.WithS3ForcePathStyle(true) // Removes need for subdomain
+	svc := s3.New(session.New(), config)
+	return svc
+}
+
+func (ts *testServer) Close() {
+	ts.server.Close()
 }
 
 func TestCreateBucket(t *testing.T) {
 	//@TODO(jb): implement them for sanity reasons
 
-	tt := TT{t}
-
-	backend := s3mem.New()
-	faker := gofakes3.New(backend)
-	ts := httptest.NewServer(faker.Server())
+	ts := newTestServer(t)
 	defer ts.Close()
 
-	config := aws.NewConfig()
-	config.WithEndpoint(ts.URL)
-	config.WithRegion("mine")
-	config.WithCredentials(credentials.NewStaticCredentials("dummy-access", "dummy-secret", ""))
-	config.WithS3ForcePathStyle(true) // Removes need for subdomain
+	svc := ts.client()
 
-	svc := s3.New(session.New(), config)
-
-	tt.OKAll(svc.CreateBucket(&s3.CreateBucketInput{
+	ts.OKAll(svc.CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String("testbucket"),
 	}))
-	tt.OKAll(svc.HeadBucket(&s3.HeadBucketInput{
+	ts.OKAll(svc.HeadBucket(&s3.HeadBucketInput{
 		Bucket: aws.String("testbucket"),
 	}))
-	tt.OKAll(svc.PutObject(&s3.PutObjectInput{
+	ts.OKAll(svc.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String("testbucket"),
 		Key:    aws.String("ObjectKey"),
 		Body:   bytes.NewReader([]byte(`{"test": "foo"}`)),
@@ -65,8 +119,66 @@ func TestCreateBucket(t *testing.T) {
 			"Key": aws.String("MetadataValue"),
 		},
 	}))
-	tt.OKAll(svc.GetObject(&s3.GetObjectInput{
+	ts.OKAll(svc.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String("testbucket"),
 		Key:    aws.String("ObjectKey"),
 	}))
+}
+
+func TestListBuckets(t *testing.T) {
+	ts := newTestServer(t, withoutInitialBuckets())
+	defer ts.Close()
+	svc := ts.client()
+
+	assertBuckets := func(expected ...string) {
+		t.Helper()
+		rs, err := svc.ListBuckets(&s3.ListBucketsInput{})
+		ts.OK(err)
+
+		var found []string
+		for _, bucket := range rs.Buckets {
+			found = append(found, *bucket.Name)
+		}
+
+		sort.Strings(expected)
+		sort.Strings(found)
+		if !reflect.DeepEqual(found, expected) {
+			t.Fatalf("buckets:\nexp: %v\ngot: %v", expected, found)
+		}
+	}
+
+	assertBucketTime := func(bucket string, created time.Time) {
+		t.Helper()
+		rs, err := svc.ListBuckets(&s3.ListBucketsInput{})
+		ts.OK(err)
+
+		for _, v := range rs.Buckets {
+			if *v.Name == bucket {
+				if *v.CreationDate != created {
+					t.Fatal("time mismatch for bucket", bucket, "expected:", created, "found:", *v.CreationDate)
+				}
+				return
+			}
+		}
+		t.Fatal("bucket", bucket, "not found")
+	}
+
+	assertBuckets()
+
+	ts.createBucket("test")
+	assertBuckets("test")
+	assertBucketTime("test", defaultDate)
+
+	ts.createBucket("test2")
+	assertBuckets("test", "test2")
+	assertBucketTime("test2", defaultDate)
+
+	ts.Advance(1 * time.Minute)
+
+	ts.createBucket("test3")
+	assertBuckets("test", "test2", "test3")
+
+	assertBucketTime("test", defaultDate)
+	assertBucketTime("test2", defaultDate)
+	assertBucketTime("test3", defaultDate.Add(1*time.Minute))
 }

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,25 @@
+package gofakes3
+
+import (
+	"testing"
+)
+
+type TT struct {
+	*testing.T
+}
+
+func (t TT) OK(err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (t TT) OKAll(vs ...interface{}) {
+	t.Helper()
+	for _, v := range vs {
+		if err, ok := v.(error); ok && err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/messages.go
+++ b/messages.go
@@ -3,15 +3,28 @@ package gofakes3
 import (
 	"encoding/xml"
 	"io"
+	"sort"
 	"time"
 )
 
 type Storage struct {
-	XMLName     xml.Name     `xml:"ListAllMyBucketsResult"`
-	Xmlns       string       `xml:"xmlns,attr"`
-	Id          string       `xml:"Owner>ID"`
-	DisplayName string       `xml:"Owner>DisplayName"`
-	Buckets     []BucketInfo `xml:"Buckets>Bucket"`
+	XMLName     xml.Name `xml:"ListAllMyBucketsResult"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Id          string   `xml:"Owner>ID"`
+	DisplayName string   `xml:"Owner>DisplayName"`
+	Buckets     Buckets  `xml:"Buckets>Bucket"`
+}
+
+type Buckets []BucketInfo
+
+// Names is a deterministic convenience function returning a sorted list of bucket names.
+func (b Buckets) Names() []string {
+	out := make([]string, len(b))
+	for i, v := range b {
+		out[i] = v.Name
+	}
+	sort.Strings(out)
+	return out
 }
 
 type BucketInfo struct {

--- a/messages_test.go
+++ b/messages_test.go
@@ -38,8 +38,28 @@ func TestContentTime(t *testing.T) {
 
 	var v = testMsg{
 		Foo:  "bar",
-		Time: ContentTime(time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC)),
+		Time: NewContentTime(time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC)),
 	}
+	out, err := xml.Marshal(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != expected {
+		t.Fatalf("unexpected XML output: %s", string(out))
+	}
+}
+
+func TestContentTimeOmitEmpty(t *testing.T) {
+	type testMsg struct {
+		Foo  string
+		Time ContentTime `xml:",omitempty"`
+	}
+	const expected = "" +
+		"<testMsg>" +
+		"<Foo>bar</Foo>" +
+		"</testMsg>"
+
+	var v = testMsg{Foo: "bar"}
 	out, err := xml.Marshal(&v)
 	if err != nil {
 		t.Fatal(err)

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,50 @@
+package gofakes3
+
+import (
+	"encoding/xml"
+	"testing"
+	"time"
+)
+
+func TestBucketAddPrefix(t *testing.T) {
+	b := NewBucket("yep")
+	b.AddPrefix("prefix1")
+	if len(b.CommonPrefixes) != 1 {
+		t.Fatal("unexpected prefixes length")
+	}
+
+	// Duplicate prefix should not alter Bucket:
+	b.AddPrefix("prefix1")
+	if len(b.CommonPrefixes) != 1 {
+		t.Fatal("unexpected prefixes length")
+	}
+
+	b.AddPrefix("prefix2")
+	if len(b.CommonPrefixes) != 2 {
+		t.Fatal("unexpected prefixes length")
+	}
+}
+
+func TestContentTime(t *testing.T) {
+	type testMsg struct {
+		Foo  string
+		Time ContentTime
+	}
+	const expected = "" +
+		"<testMsg>" +
+		"<Foo>bar</Foo>" +
+		"<Time>2019-01-01T12:00:00Z</Time>" +
+		"</testMsg>"
+
+	var v = testMsg{
+		Foo:  "bar",
+		Time: ContentTime(time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC)),
+	}
+	out, err := xml.Marshal(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != expected {
+		t.Fatalf("unexpected XML output: %s", string(out))
+	}
+}

--- a/option.go
+++ b/option.go
@@ -4,6 +4,11 @@ import "time"
 
 type Option func(g *GoFakeS3)
 
+// WithTimeSource allows you to substitute the behaviour of time.Now() and
+// time.Since() within GoFakeS3. This can be used to trigger time skew errors,
+// or to ensure the output of the commands is deterministic.
+//
+// See gofakes3.FixedTimeSource(), gofakes3.LocalTimeSource(tz).
 func WithTimeSource(timeSource TimeSource) Option {
 	return func(g *GoFakeS3) { g.timeSource = timeSource }
 }

--- a/prefix.go
+++ b/prefix.go
@@ -1,0 +1,123 @@
+package gofakes3
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type Prefix struct {
+	HasPrefix bool
+	Prefix    string
+
+	HasDelimiter bool
+	Delimiter    string
+}
+
+func prefixFromQuery(query url.Values) Prefix {
+	prefix := Prefix{
+		Prefix:    query.Get("prefix"),
+		Delimiter: query.Get("delimiter"),
+	}
+	_, prefix.HasPrefix = query["prefix"]
+	_, prefix.HasDelimiter = query["delimiter"]
+	return prefix
+}
+
+// PrefixMatch checks whether key starts with prefix. If the prefix does not
+// match, nil is returned.
+//
+// It is a best-effort attempt to implement the prefix/delimiter matching found
+// in S3.
+//
+// To check whether the key belongs in Contents or CommonPrefixes, compare the
+// result to key.
+//
+func (p Prefix) Match(key string) (match *PrefixMatch) {
+	if !p.HasPrefix {
+		// If there is no prefix, in the search, the match is the prefix:
+		return &PrefixMatch{Key: key, MatchedPart: key}
+	}
+
+	if !p.HasDelimiter {
+		// If the request does not contain a delimiter, prefix matching is a
+		// simple string prefix:
+		if strings.HasPrefix(key, p.Prefix) {
+			return &PrefixMatch{Key: key, MatchedPart: p.Prefix}
+		}
+		return nil
+	}
+
+	// Delimited + Prefix matches, for example:
+	//	 $ aws s3 ls s3://my-bucket/
+	//	                            PRE AWSLogs/
+	//	 $ aws s3 ls s3://my-bucket/AWSLogs
+	//	                            PRE AWSLogs/
+	//	 $ aws s3 ls s3://my-bucket/AWSLogs/
+	//	                            PRE 260839334643/
+	//	 $ aws s3 ls s3://my-bucket/AWSLogs/2608
+	//	                            PRE 260839334643/
+
+	keyParts := strings.Split(strings.TrimLeft(key, p.Delimiter), p.Delimiter)
+	preParts := strings.Split(strings.TrimLeft(p.Prefix, p.Delimiter), p.Delimiter)
+
+	if len(keyParts) < len(preParts) {
+		return nil
+	}
+
+	// If the key exactly matches the prefix, but only up to a delimiter,
+	// AWS appends the delimiter to the result:
+	//	 $ aws s3 ls s3://my-bucket/AWSLogs
+	//	                            PRE AWSLogs/
+	appendDelim := len(keyParts) != len(preParts)
+	matched := 0
+
+	last := len(preParts) - 1
+	for i := 0; i < len(preParts); i++ {
+		if i == last {
+			if !strings.HasPrefix(keyParts[i], preParts[i]) {
+				return nil
+			}
+
+		} else {
+			if keyParts[i] != preParts[i] {
+				return nil
+			}
+		}
+		matched++
+	}
+
+	if matched == 0 {
+		return nil
+	}
+
+	out := strings.Join(keyParts[:matched], p.Delimiter)
+	if appendDelim {
+		out += p.Delimiter
+	}
+
+	return &PrefixMatch{Key: key, CommonPrefix: out != key, MatchedPart: out}
+}
+
+func (p Prefix) String() string {
+	if !p.HasPrefix {
+		return "<prefix empty>"
+	}
+	if p.HasDelimiter {
+		return fmt.Sprintf("prefix:%q, delim:%q", p.Prefix, p.Delimiter)
+	} else {
+		return fmt.Sprintf("prefix:%q", p.Prefix)
+	}
+}
+
+type PrefixMatch struct {
+	// Input key passed to PrefixMatch.
+	Key string
+
+	// CommonPrefix indicates whether this key should be returned in the bucket
+	// contents or the common prefixes part of the "list bucket" response.
+	CommonPrefix bool
+
+	// The longest matched part of the key.
+	MatchedPart string
+}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1,0 +1,66 @@
+package gofakes3
+
+import (
+	"testing"
+)
+
+func TestPrefixMatch(t *testing.T) {
+	// Cheapo helpers for hiding pointer strings, used to increase information density
+	// in the test case table:
+	s := func(v string) *string { return &v }
+	unwrap := func(v *string) string {
+		if v != nil {
+			return *v
+		}
+		return ""
+	}
+
+	for idx, tc := range []struct {
+		key    string
+		p      *string
+		d      *string
+		out    *string
+		common bool
+	}{
+		{key: "foo/bar", p: s("foo"), d: s("/"), out: s("foo/"), common: true},
+		{key: "foo/bar", p: s("foo/ba"), d: s("/"), out: s("foo/bar")},
+		{key: "foo/bar", p: s("foo/ba/"), d: s("/"), out: nil},
+		{key: "foo/bar", p: s("/"), d: s("/"), out: s("foo/"), common: true},
+
+		// Without a delimiter, it's just a boring ol' prefix match:
+		{key: "foo/bar", p: s("foo/b"), out: s("foo/b")},
+		{key: "foo/bar", p: s("foo/"), out: s("foo/")},
+		{key: "foo/bar", p: s("foo"), out: s("foo")},
+		{key: "foo/bar", p: s("fo"), out: s("fo")},
+		{key: "foo/bar", p: s("f"), out: s("f")},
+		{key: "foo/bar", p: s("q"), out: nil},
+
+		// This could be a source of trouble - does "no prefix" mean "match
+		// everything" or "match nothing"? What about "empty prefix"? For now,
+		// these cases simply document what the curret algorithm is expected to
+		// do, but this needs further exploration:
+		{key: "foo/bar", p: nil, out: s("foo/bar")},
+		{key: "foo/bar", p: s(""), out: s("")},
+	} {
+		t.Run("", func(t *testing.T) {
+			prefix := Prefix{
+				HasPrefix:    tc.p != nil,
+				HasDelimiter: tc.d != nil,
+				Prefix:       unwrap(tc.p),
+				Delimiter:    unwrap(tc.d),
+			}
+			match := prefix.Match(tc.key)
+			if (tc.out == nil) != (match == nil) {
+				t.Fatal("prefix match failed at index", idx)
+			}
+			if tc.out != nil {
+				if *tc.out != match.MatchedPart {
+					t.Fatal("prefix matched part failed at index", idx, *tc.out, "!=", match.MatchedPart)
+				}
+				if tc.common != match.CommonPrefix {
+					t.Fatal("prefix common failed at index", idx)
+				}
+			}
+		})
+	}
+}

--- a/time.go
+++ b/time.go
@@ -7,6 +7,17 @@ type TimeSource interface {
 	Since(time.Time) time.Duration
 }
 
+type TimeSourceAdvancer interface {
+	TimeSource
+	Advance(by time.Duration)
+}
+
+// FixedTimeSource provides a source of time that always returns the
+// specified time.
+func FixedTimeSource(at time.Time) TimeSourceAdvancer {
+	return &fixedTimeSource{time: at}
+}
+
 func DefaultTimeSource() TimeSource {
 	timeLocation, err := time.LoadLocation("GMT")
 	if err != nil {
@@ -27,4 +38,20 @@ func (l *locatedTimeSource) Now() time.Time {
 
 func (l *locatedTimeSource) Since(t time.Time) time.Duration {
 	return time.Since(t)
+}
+
+type fixedTimeSource struct {
+	time time.Time
+}
+
+func (l *fixedTimeSource) Now() time.Time {
+	return l.time
+}
+
+func (l *fixedTimeSource) Since(t time.Time) time.Duration {
+	return t.Sub(l.time)
+}
+
+func (l *fixedTimeSource) Advance(by time.Duration) {
+	l.time = l.time.Add(by)
 }


### PR DESCRIPTION
This PR adds support for Prefix/Delimiter matching. It makes gofakes3 respond as you'd expect when using the AWS CLI to list folders.

I thought I was finished last night, but I ran into some regressions around creation date and bucket listing when I decided to test a bit further, so I put some work into the test suite. What I have here is a little messy; I intend to clean it up over time as new bits emerge. I like writing high-density test cases with a lot of custom assertions and wrappers that encapsulate the noise. As the API for testing gets more polished over time, the test cases start to read like a specification of behaviour rather than an imperative mechanism for actually running the test. The direction I think the testing API should iterate towards should eventually allow us to use most of the test cases to certify any backend as functioning. This will take some time though.

Most of how I've been verifying my own changes work involves crappy bash scripts with the AWS CLI, which has been a really good way to flush out quirks that break my expectations and to sniff out the expected response, but isn't good for catching regressions. I've attempted to start working this in to a test suite of its own (awscli_test.go), which has some advantages and some drawbacks. On the plus side, it means that we can guarantee various facets of the command line will meet user's expectations, and we are also implicitly testing gofakes3 with botocore this way. On the minus side, it's slow as a wet week, so I'd be reluctant to go crazy adding too many cases that use the CLI.

It might be worth us pulling in an assertion library, too. The little TT struct I added is a cut-down version of my simple assertion lib, but it doesn't report error lines properly. The entire library is small enough to copy and paste around, weighing in at around 150 lines of actual code. This is my preferred approach, but the testify/assert library is another very good option that merits consideration. I would prefer not to use the whole of testify, only the testify/assert bit.

Apologies for the test failures, I have no idea why CircleCI fails the tests while they pass just fine on my machine after a fresh clone.