### PR TITLE
Stdlib-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,5 @@ exports.handle = function (e, ctx) {
 
 ## Contributors
 
+- [Johannes Boyne @johannesboyne](https://github.com/johannesboyne)
 - [Blake Williams @shabbyrobe](https://github.com/shabbyrobe)

--- a/cors.go
+++ b/cors.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-
-	"github.com/gorilla/mux"
 )
 
 var (
@@ -30,7 +28,7 @@ var (
 )
 
 type WithCORS struct {
-	r *mux.Router
+	r http.Handler
 }
 
 func (s *WithCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/gorilla/mux"
 )
 
 const (
@@ -60,23 +58,8 @@ func New(backend Backend, options ...Option) *GoFakeS3 {
 
 // Create the AWS S3 API
 func (g *GoFakeS3) Server() http.Handler {
-	r := mux.NewRouter()
-	r.Queries("marker", "prefix")
-	// BUCKET
-	r.HandleFunc("/", g.GetBuckets).Methods("GET")
-	r.HandleFunc("/{BucketName}", g.GetBucket).Methods("GET")
-	r.HandleFunc("/{BucketName}", g.CreateBucket).Methods("PUT")
-	r.HandleFunc("/{BucketName}", g.DeleteBucket).Methods("DELETE")
-	r.HandleFunc("/{BucketName}", g.HeadBucket).Methods("HEAD")
-	// OBJECT
-	r.HandleFunc("/{BucketName}/", g.CreateObjectBrowserUpload).Methods("POST")
-	r.HandleFunc("/{BucketName}/{ObjectName:.{1,}}", g.GetObject).Methods("GET")
-	r.HandleFunc("/{BucketName}/{ObjectName:.{1,}}", g.CreateObject).Methods("PUT")
-	r.HandleFunc("/{BucketName}/{ObjectName:.{0,}}", g.CreateObject).Methods("POST")
-	r.HandleFunc("/{BucketName}/{ObjectName:.{1,}}", g.DeleteObject).Methods("DELETE")
-	r.HandleFunc("/{BucketName}/{ObjectName:.{0,}}", g.HeadObject).Methods("HEAD")
+	wc := &WithCORS{http.HandlerFunc(g.routeBase)}
 
-	wc := &WithCORS{r}
 	hf := func(w http.ResponseWriter, rq *http.Request) {
 		timeHdr := rq.Header.Get("x-amz-date")
 
@@ -121,11 +104,10 @@ func (g *GoFakeS3) httpError(w http.ResponseWriter, r *http.Request, err error) 
 }
 
 // Get a list of all Buckets
-func (g *GoFakeS3) GetBuckets(w http.ResponseWriter, r *http.Request) {
+func (g *GoFakeS3) getBuckets(w http.ResponseWriter, r *http.Request) error {
 	buckets, err := g.storage.ListBuckets()
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 
 	s := &Storage{
@@ -136,20 +118,18 @@ func (g *GoFakeS3) GetBuckets(w http.ResponseWriter, r *http.Request) {
 	}
 	x, err := xml.MarshalIndent(s, "", "  ")
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.Write([]byte(xml.Header))
 	w.Write(x)
+	return nil
 }
 
 // GetBucket lists the contents of a bucket.
-func (g *GoFakeS3) GetBucket(w http.ResponseWriter, r *http.Request) {
+func (g *GoFakeS3) getBucket(bucketName string, w http.ResponseWriter, r *http.Request) error {
 	log.Println("GET BUCKET")
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
 
 	prefix := prefixFromQuery(r.URL.Query())
 
@@ -158,92 +138,73 @@ func (g *GoFakeS3) GetBucket(w http.ResponseWriter, r *http.Request) {
 
 	bucket, err := g.storage.GetBucket(bucketName, prefix)
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 
 	x, err := xml.MarshalIndent(bucket, "", "  ")
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.Write([]byte(xml.Header))
 	w.Write(x)
+	return nil
 }
 
 // CreateBucket creates a new S3 bucket in the BoltDB storage.
-func (g *GoFakeS3) CreateBucket(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
-	log.Println("CREATE BUCKET:", bucketName)
+func (g *GoFakeS3) createBucket(bucket string, w http.ResponseWriter, r *http.Request) error {
+	log.Println("CREATE BUCKET:", bucket)
 
-	if err := ValidateBucketName(bucketName); err != nil {
-		g.httpError(w, r, err)
-		return
+	if err := ValidateBucketName(bucket); err != nil {
+		return err
 	}
-
-	if err := g.storage.CreateBucket(bucketName); err != nil {
-		g.httpError(w, r, err)
-		return
+	if err := g.storage.CreateBucket(bucket); err != nil {
+		return err
 	}
 
 	w.Header().Set("Host", r.Header.Get("Host"))
-	w.Header().Set("Location", "/"+bucketName)
+	w.Header().Set("Location", "/"+bucket)
 	w.Write([]byte{})
+	return nil
 }
 
 // DeleteBucket creates a new S3 bucket in the BoltDB storage.
-func (g *GoFakeS3) DeleteBucket(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
-	log.Println("DELETE BUCKET:", bucketName)
-
-	if err := g.storage.DeleteBucket(bucketName); err != nil {
-		g.httpError(w, r, err)
-		return
-	}
+func (g *GoFakeS3) deleteBucket(bucket string, w http.ResponseWriter, r *http.Request) error {
+	log.Println("DELETE BUCKET:", bucket)
+	return g.storage.DeleteBucket(bucket)
 }
 
 // HeadBucket checks whether a bucket exists.
-func (g *GoFakeS3) HeadBucket(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
-	log.Println("HEAD BUCKET", bucketName)
-	log.Println("bucketname:", bucketName)
+func (g *GoFakeS3) headBucket(bucket string, w http.ResponseWriter, r *http.Request) error {
+	log.Println("HEAD BUCKET", bucket)
+	log.Println("bucketname:", bucket)
 
-	exists, err := g.storage.BucketExists(bucketName)
+	exists, err := g.storage.BucketExists(bucket)
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 	if !exists {
-		http.NotFound(w, r)
-		return
+		return ResourceError(ErrNoSuchBucket, bucket)
 	}
 
 	w.Header().Set("x-amz-id-2", "LriYPLdmOdAiIfgSm/F1YsViT1LW94/xUQxMsF7xiEb1a0wiIOIxl+zbwZ163pt7")
 	w.Header().Set("x-amz-request-id", "0A49CE4060975EAC")
 	w.Header().Set("Server", "AmazonS3")
 	w.Write([]byte{})
+	return nil
 }
 
 // GetObject retrievs a bucket object.
-func (g *GoFakeS3) GetObject(w http.ResponseWriter, r *http.Request) {
+func (g *GoFakeS3) getObject(bucket, object string, w http.ResponseWriter, r *http.Request) error {
 	log.Println("GET OBJECT")
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
-	objectName := vars["ObjectName"]
 
-	log.Println("Bucket:", bucketName)
-	log.Println("└── Object:", vars["ObjectName"])
+	log.Println("Bucket:", bucket)
+	log.Println("└── Object:", object)
 
-	obj, err := g.storage.GetObject(bucketName, objectName)
-
+	obj, err := g.storage.GetObject(bucket, object)
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 	defer obj.Contents.Close()
 
@@ -258,32 +219,29 @@ func (g *GoFakeS3) GetObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", obj.Size))
 
 	if _, err := io.Copy(w, obj.Contents); err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
+
+	return nil
 }
 
 // CreateObject (Browser Upload) creates a new S3 object.
-func (g *GoFakeS3) CreateObjectBrowserUpload(w http.ResponseWriter, r *http.Request) {
+func (g *GoFakeS3) createObjectBrowserUpload(bucket string, w http.ResponseWriter, r *http.Request) error {
 	log.Println("CREATE OBJECT THROUGH BROWSER UPLOAD")
 	const _24MB = (1 << 20) * 24
 	if err := r.ParseMultipartForm(_24MB); nil != err {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
 	key := r.MultipartForm.Value["key"][0]
 
-	log.Println("(BUC)", bucketName)
+	log.Println("(BUC)", bucket)
 	log.Println("(KEY)", key)
 	fileHeader := r.MultipartForm.File["file"][0]
 
 	infile, err := fileHeader.Open()
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 	defer infile.Close()
 
@@ -296,18 +254,15 @@ func (g *GoFakeS3) CreateObjectBrowserUpload(w http.ResponseWriter, r *http.Requ
 	meta["Last-Modified"] = formatHeaderTime(g.timeSource.Now())
 
 	if g.metadataSizeLimit > 0 && metadataSize(meta) > g.metadataSizeLimit {
-		g.httpError(w, r, ErrMetadataTooLarge)
-		return
+		return ErrMetadataTooLarge
 	}
 
 	if len(key) > KeySizeLimit {
-		g.httpError(w, r, ResourceError(ErrKeyTooLong, key))
-		return
+		return ResourceError(ErrKeyTooLong, key)
 	}
 
-	if err := g.storage.PutObject(bucketName, key, meta, infile); err != nil {
-		g.httpError(w, r, err)
-		return
+	if err := g.storage.PutObject(bucket, key, meta, infile); err != nil {
+		return err
 	}
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -316,15 +271,13 @@ func (g *GoFakeS3) CreateObjectBrowserUpload(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("ETag", "\"fbacf535f27731c9771645a39863328\"")
 	w.Header().Set("Server", "AmazonS3")
 	w.Write([]byte{})
+
+	return nil
 }
 
 // CreateObject creates a new S3 object.
-func (g *GoFakeS3) CreateObject(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
-	objectName := vars["ObjectName"]
-
-	log.Println("CREATE OBJECT:", bucketName, objectName)
+func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r *http.Request) error {
+	log.Println("CREATE OBJECT:", bucket, object)
 
 	meta := make(map[string]string)
 	for hk, hv := range r.Header {
@@ -334,14 +287,12 @@ func (g *GoFakeS3) CreateObject(w http.ResponseWriter, r *http.Request) {
 	}
 	meta["Last-Modified"] = formatHeaderTime(g.timeSource.Now())
 
-	if len(objectName) > KeySizeLimit {
-		g.httpError(w, r, ResourceError(ErrKeyTooLong, objectName))
-		return
+	if len(object) > KeySizeLimit {
+		return ResourceError(ErrKeyTooLong, object)
 	}
 
-	if err := g.storage.PutObject(bucketName, objectName, meta, r.Body); err != nil {
-		g.httpError(w, r, err)
-		return
+	if err := g.storage.PutObject(bucket, object, meta, r.Body); err != nil {
+		return err
 	}
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -350,39 +301,31 @@ func (g *GoFakeS3) CreateObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("ETag", "\"fbacf535f27731c9771645a39863328\"")
 	w.Header().Set("Server", "AmazonS3")
 	w.Write([]byte{})
+
+	return nil
 }
 
 // DeleteObject deletes a S3 object from the bucket.
-func (g *GoFakeS3) DeleteObject(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
-	objectName := vars["ObjectName"]
-
-	log.Println("DELETE:", bucketName, objectName)
-
-	if err := g.storage.DeleteObject(bucketName, objectName); err != nil {
-		g.httpError(w, r, err)
-		return
+func (g *GoFakeS3) deleteObject(bucket, object string, w http.ResponseWriter, r *http.Request) error {
+	log.Println("DELETE:", bucket, object)
+	if err := g.storage.DeleteObject(bucket, object); err != nil {
+		return err
 	}
-
 	w.Header().Set("x-amz-delete-marker", "false")
 	w.Write([]byte{})
+	return nil
 }
 
 // HeadObject retrieves only meta information of an object and not the whole.
-func (g *GoFakeS3) HeadObject(w http.ResponseWriter, r *http.Request) {
+func (g *GoFakeS3) headObject(bucket, object string, w http.ResponseWriter, r *http.Request) error {
 	log.Println("HEAD OBJECT")
-	vars := mux.Vars(r)
-	bucketName := vars["BucketName"]
-	objectName := vars["ObjectName"]
 
-	log.Println("Bucket:", bucketName)
-	log.Println("└── Object:", objectName)
+	log.Println("Bucket:", bucket)
+	log.Println("└── Object:", object)
 
-	obj, err := g.storage.HeadObject(bucketName, objectName)
+	obj, err := g.storage.HeadObject(bucket, object)
 	if err != nil {
-		g.httpError(w, r, err)
-		return
+		return err
 	}
 	defer obj.Contents.Close()
 
@@ -397,6 +340,8 @@ func (g *GoFakeS3) HeadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", obj.Size))
 	w.Header().Set("Connection", "close")
 	w.Write([]byte{})
+
+	return nil
 }
 
 func formatHeaderTime(t time.Time) string {

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -2,6 +2,7 @@ package gofakes3_test
 
 import (
 	"bytes"
+	"fmt"
 	"net/http/httptest"
 	"reflect"
 	"sort"
@@ -69,6 +70,10 @@ func newTestServer(t *testing.T, opts ...testServerOption) *testServer {
 	}
 
 	return &ts
+}
+
+func (ts *testServer) url(url string) string {
+	return fmt.Sprintf("%s/%s", ts.server.URL, strings.TrimLeft(url, "/"))
 }
 
 func (ts *testServer) createBucket(bucket string) {

--- a/routing.go
+++ b/routing.go
@@ -1,0 +1,85 @@
+package gofakes3
+
+import (
+	"net/http"
+	"strings"
+)
+
+// routeBase is a http.HandlerFunc that dispatches top level routes for
+// GoFakeS3.
+//
+// URLs are assumed to break down into two common path segments, in the
+// following format:
+//   /<bucket>/<object>
+//
+// The operation for most of the core functionality is built around HTTP
+// verbs, but outside the core functionality, the clean separation starts
+// to degrade, especially around multipart uploads.
+//
+func (g *GoFakeS3) routeBase(w http.ResponseWriter, r *http.Request) {
+	var (
+		path   = strings.Trim(r.URL.Path, "/")
+		parts  = strings.SplitN(path, "/", 2)
+		bucket = parts[0]
+		object = ""
+		err    error
+	)
+
+	if len(parts) == 2 {
+		object = parts[1]
+	}
+
+	if bucket != "" && object != "" {
+		err = g.routeObject(bucket, object, w, r)
+
+	} else if bucket != "" {
+		err = g.routeBucket(bucket, w, r)
+
+	} else if r.Method == "GET" {
+		err = g.getBuckets(w, r)
+
+	} else {
+		http.NotFound(w, r)
+		return
+	}
+
+	if err != nil {
+		g.httpError(w, r, err)
+	}
+}
+
+// routeObject oandles URLs that contain both a bucket path segment and an
+// object path segment.
+func (g *GoFakeS3) routeObject(bucket, object string, w http.ResponseWriter, r *http.Request) (err error) {
+	switch r.Method {
+	case "GET":
+		return g.getObject(bucket, object, w, r)
+	case "PUT":
+		return g.createObject(bucket, object, w, r)
+	case "DELETE":
+		return g.deleteObject(bucket, object, w, r)
+	case "HEAD":
+		return g.headObject(bucket, object, w, r)
+	default:
+		return ErrMethodNotAllowed
+	}
+}
+
+// routeBucket handles URLs that contain only a bucket path segment, not an
+// object path segment.
+func (g *GoFakeS3) routeBucket(bucket string, w http.ResponseWriter, r *http.Request) (err error) {
+	switch r.Method {
+	case "GET":
+		return g.getBucket(bucket, w, r)
+	case "PUT":
+		return g.createBucket(bucket, w, r)
+	case "DELETE":
+		return g.deleteBucket(bucket, w, r)
+	case "HEAD":
+		return g.headBucket(bucket, w, r)
+	case "POST":
+		return g.createObjectBrowserUpload(bucket, w, r)
+	default:
+		return ErrMethodNotAllowed
+	}
+}

--- a/routing_test.go
+++ b/routing_test.go
@@ -1,0 +1,36 @@
+package gofakes3_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRoutingSlashes(t *testing.T) {
+	ts := newTestServer(t, withoutInitialBuckets())
+	defer ts.Close()
+	ts.createBucket("test")
+	ts.putString("test", "obj", nil, "yep")
+
+	client := &http.Client{
+		Timeout: 1 * time.Second,
+	}
+
+	assertStatus := func(url string, code int) {
+		t.Helper()
+		rs, err := client.Head(ts.url(url))
+		ts.OK(err)
+		if rs.StatusCode != code {
+			t.Fatal("expected status", code, "found", rs.StatusCode)
+		}
+	}
+
+	assertStatus("nope", 404) // sanity check missing URL
+	assertStatus("test", 200)
+	assertStatus("test/", 200)
+	assertStatus("test//", 200) // don't care how many slashes
+	assertStatus("test/nope", 404)
+	assertStatus("test/obj", 200)
+	assertStatus("test/obj/", 200)
+	assertStatus("test/obj//", 200)
+}


### PR DESCRIPTION
This is an important step to introducing multipart uploads (coming in the next PR 😄), which make a complete mess of the nice clean routing. It really feels like S3 started out with a clean restish API that only did simple CRUD on buckets and objects, then they just started stapling stuff to the side one piece at a time with little regard for consistency.

This PR also unexports the GoFakeS3 handler functions. I've done this in order to limit the surface of supported API for now, it's not something I think should necessarily be permanent, it's more just to paint a smaller compatibility target that we have to support in the near term. This comes with the risk of breaking existing user code that might be calling these handlers directly, though the suggested upgrade path would be to call the backend directly anyway, which is built to be called from code as opposed to HTTP. I'm not married to the unexporting aspect - it'll take 30 seconds to re-export if it turns out I'm breaking something you're relying on!

Things might be in slightly too much flux for this at the moment (and I think the README already does a good job of making the level of stability a user could expect clear), but we should definitely look at version numbering at some point in the future and a stable API surface is a critical part of that. 