### PR TITLE
Content-MD5 validation

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -43,8 +43,12 @@ type Backend interface {
 	// AWS does not validate the bucket's name for anything other than existence.
 	DeleteBucket(name string) error
 
-	// GetObject must return a gofakes3.ErrNoSuchKey error if the object does not exist.
-	// See gofakes3.KeyNotFound() for a convenient way to create one.
+	// GetObject must return a gofakes3.ErrNoSuchKey error if the object does
+	// not exist.  See gofakes3.KeyNotFound() for a convenient way to create
+	// one.
+	//
+	// If the returned Object is not nil, you MUST call Object.Contents.Close(),
+	// otherwise you will leak resources.
 	GetObject(bucketName, objectName string) (*Object, error)
 
 	// DeleteObject deletes an object from the bucket.

--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -26,6 +26,7 @@ func run() error {
 		backendKind  string
 		bucket       string
 		fixedTimeStr string
+		noIntegrity  bool
 	)
 
 	flag.StringVar(&db, "db", "locals3.db", "Database path / name when using bolt backend")
@@ -33,6 +34,7 @@ func run() error {
 	flag.StringVar(&backendKind, "backend", "", "Backend to use to store data (memory, bolt)")
 	flag.StringVar(&bucket, "bucket", "fakes3", "Bucket to create by default (required)")
 	flag.StringVar(&fixedTimeStr, "time", "", "RFC3339 format. If passed, the server's clock will always see this time; does not affect existing stored dates.")
+	flag.BoolVar(&noIntegrity, "no-integrity", false, "Pass this flag to disable Content-MD5 validation when uploading.")
 	flag.Parse()
 
 	if bucket == "" {
@@ -85,6 +87,7 @@ func run() error {
 	faker := gofakes3.New(backend,
 		gofakes3.WithTimeSource(timeSource),
 		gofakes3.WithTimeSkewLimit(timeSkewLimit),
+		gofakes3.WithIntegrityCheck(!noIntegrity),
 	)
 	return listenAndServe(host, faker.Server())
 }

--- a/error.go
+++ b/error.go
@@ -27,6 +27,9 @@ const (
 	// HTTP header:
 	ErrIncompleteBody ErrorCode = "IncompleteBody"
 
+	// POST requires exactly one file upload per request.
+	ErrIncorrectNumberOfFilesInPostRequest ErrorCode = "IncorrectNumberOfFilesInPostRequest"
+
 	// InlineDataTooLarge occurs when using the PutObjectInline method of the
 	// SOAP interface
 	// (https://docs.aws.amazon.com/AmazonS3/latest/API/SOAPPutObjectInline.html).
@@ -171,6 +174,7 @@ func (e ErrorCode) Status() int {
 
 	case ErrBadDigest,
 		ErrIncompleteBody,
+		ErrIncorrectNumberOfFilesInPostRequest,
 		ErrInlineDataTooLarge,
 		ErrInvalidBucketName,
 		ErrInvalidDigest,

--- a/error.go
+++ b/error.go
@@ -15,6 +15,9 @@ import (
 const (
 	ErrNone ErrorCode = ""
 
+	// The Content-MD5 you specified did not match what we received.
+	ErrBadDigest ErrorCode = "BadDigest"
+
 	ErrBucketAlreadyExists ErrorCode = "BucketAlreadyExists"
 
 	// Raised when attempting to delete a bucket that still contains items.
@@ -24,13 +27,24 @@ const (
 	// HTTP header:
 	ErrIncompleteBody ErrorCode = "IncompleteBody"
 
+	// InlineDataTooLarge occurs when using the PutObjectInline method of the
+	// SOAP interface
+	// (https://docs.aws.amazon.com/AmazonS3/latest/API/SOAPPutObjectInline.html).
+	// This is not documented on the errors page; the error is included here
+	// only for reference.
+	ErrInlineDataTooLarge ErrorCode = "InlineDataTooLarge"
+
+	// The Content-MD5 you specified is not valid.
+	ErrInvalidDigest ErrorCode = "InvalidDigest"
+
 	// https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
 	ErrInvalidBucketName ErrorCode = "InvalidBucketName"
 
-	ErrKeyTooLong       ErrorCode = "KeyTooLongError"
-	ErrMetadataTooLarge ErrorCode = "MetadataTooLarge"
-	ErrMethodNotAllowed ErrorCode = "MethodNotAllowed"
-	ErrMalformedXML     ErrorCode = "MalformedXML"
+	ErrKeyTooLong           ErrorCode = "KeyTooLongError" // This is not a typo: Error is part of the string, but redundant in the constant name
+	ErrMalformedPOSTRequest ErrorCode = "MalformedPOSTRequest"
+	ErrMetadataTooLarge     ErrorCode = "MetadataTooLarge"
+	ErrMethodNotAllowed     ErrorCode = "MethodNotAllowed"
+	ErrMalformedXML         ErrorCode = "MalformedXML"
 
 	// See BucketNotFound() for a helper function for this error:
 	ErrNoSuchBucket ErrorCode = "NoSuchBucket"
@@ -142,6 +156,8 @@ func (e ErrorCode) Message() string {
 		return "The specified bucket does not exist"
 	case ErrRequestTimeTooSkewed:
 		return "The difference between the request time and the current time is too large"
+	case ErrMalformedXML:
+		return "The XML you provided was not well-formed or did not validate against our published schema"
 	default:
 		return ""
 	}
@@ -153,11 +169,15 @@ func (e ErrorCode) Status() int {
 		ErrBucketNotEmpty:
 		return http.StatusConflict
 
-	case ErrIncompleteBody,
+	case ErrBadDigest,
+		ErrIncompleteBody,
+		ErrInlineDataTooLarge,
 		ErrInvalidBucketName,
+		ErrInvalidDigest,
 		ErrKeyTooLong,
 		ErrMetadataTooLarge,
 		ErrMethodNotAllowed,
+		ErrMalformedPOSTRequest,
 		ErrMalformedXML,
 		ErrTooManyBuckets:
 		return http.StatusBadRequest

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -238,7 +238,7 @@ func (g *GoFakeS3) createObjectBrowserUpload(bucket string, w http.ResponseWrite
 
 	keyValues := r.MultipartForm.Value["key"]
 	if len(keyValues) != 1 {
-		return ErrMalformedPOSTRequest
+		return ErrIncorrectNumberOfFilesInPostRequest
 	}
 	key := keyValues[0]
 
@@ -247,7 +247,7 @@ func (g *GoFakeS3) createObjectBrowserUpload(bucket string, w http.ResponseWrite
 
 	fileValues := r.MultipartForm.File["file"]
 	if len(fileValues) != 1 {
-		return ErrMalformedPOSTRequest
+		return ErrIncorrectNumberOfFilesInPostRequest
 	}
 	fileHeader := fileValues[0]
 

--- a/hash.go
+++ b/hash.go
@@ -1,0 +1,56 @@
+package gofakes3
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// hashingReader proxies an existing io.Reader, passing each read block to the
+// given hash.Hash. Once the underlying reader returns EOF, the hash is checked.
+type hashingReader struct {
+	inner    io.Reader
+	expected []byte
+	hash     hash.Hash
+}
+
+func newHashingReader(inner io.Reader, expectedMD5Base64 string) (*hashingReader, error) {
+	md5Bytes, err := base64.StdEncoding.DecodeString(expectedMD5Base64)
+	if err != nil {
+		return nil, ErrInvalidDigest
+	}
+
+	return &hashingReader{
+		inner:    inner,
+		expected: md5Bytes,
+		hash:     md5.New(),
+	}, nil
+}
+
+func (h *hashingReader) Read(p []byte) (n int, err error) {
+	n, err = h.inner.Read(p)
+
+	if n != 0 {
+		wn, _ := h.hash.Write(p[:n]) // Hash.Write never returns an error.
+		if wn != n {
+			return n, fmt.Errorf("short write to hasher")
+		}
+	}
+
+	if err != nil {
+		if err == io.EOF {
+			hash := h.hash.Sum(nil)
+			if !bytes.Equal(hash, h.expected) {
+				// FIXME: some more context here would be useful; need to flush out
+				// what S3 responds with in this case.
+				return n, ErrBadDigest
+			}
+		}
+		return n, err
+	}
+
+	return n, nil
+}

--- a/option.go
+++ b/option.go
@@ -31,3 +31,9 @@ func WithTimeSkewLimit(skew time.Duration) Option {
 func WithMetadataSizeLimit(size int) Option {
 	return func(g *GoFakeS3) { g.metadataSizeLimit = size }
 }
+
+// WithIntegrityCheck enables or disables Content-MD5 validation when
+// putting an Object.
+func WithIntegrityCheck(check bool) Option {
+	return func(g *GoFakeS3) { g.integrityCheck = check }
+}


### PR DESCRIPTION
This one's relatively simple, it extends PutObject to validate the supplied Content-MD5 on upload. I haven't added it to the browser form upload yet as I'm still not 100% across that method and would like to investigate further at some point in the future. I did however add some panic-proofing and error codes to it while I was poking around so I've at least made some progress 😆 