### PR TITLE
Multi-delete support

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -75,4 +75,6 @@ type Backend interface {
 	// PutObject should assume that the key is valid.
 	// meta may be nil.
 	PutObject(bucketName, key string, meta map[string]string, input io.Reader) error
+
+	DeleteMulti(bucketName string, objects ...string) (DeleteResult, error)
 }

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -212,6 +212,25 @@ func (db *Backend) DeleteObject(bucketName, objectName string) error {
 	return nil
 }
 
+func (db *Backend) DeleteMulti(bucketName string, objects ...string) (result gofakes3.DeleteResult, err error) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	bucket := db.buckets[bucketName]
+	if bucket == nil {
+		return result, gofakes3.BucketNotFound(bucketName)
+	}
+
+	for _, object := range objects {
+		delete(bucket.data, object)
+		result.Deleted = append(result.Deleted, gofakes3.ObjectID{
+			Key: object,
+		})
+	}
+
+	return result, nil
+}
+
 type readerWithDummyCloser struct{ io.Reader }
 
 func (d readerWithDummyCloser) Close() error { return nil }

--- a/init_internal_test.go
+++ b/init_internal_test.go
@@ -1,0 +1,36 @@
+package gofakes3
+
+// Initialisation file for tests in the 'gofakes3' package. Internal tests, unit
+// tests that use struct internals, etc go in this package.
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+)
+
+type TT struct {
+	*testing.T
+}
+
+func (t TT) OK(err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (t TT) OKAll(vs ...interface{}) {
+	t.Helper()
+	for _, v := range vs {
+		if err, ok := v.(error); ok && err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func init() {
+	// Tests that may cause log output that merits inspection belong in
+	// gofakes3_test.
+	log.SetOutput(ioutil.Discard)
+}

--- a/init_test.go
+++ b/init_test.go
@@ -1,25 +1,60 @@
-package gofakes3
+package gofakes3_test
+
+// Initialisation file for tests in the 'gofakes3_test' package. Integration tests
+// and the like go in this package as we are unable to use backends without the
+// '_test' suffix without causing an import cycle.
 
 import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
 	"testing"
 )
 
-type TT struct {
-	*testing.T
-}
+var (
+	logFile string
+)
 
-func (t TT) OK(err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func (t TT) OKAll(vs ...interface{}) {
-	t.Helper()
-	for _, v := range vs {
-		if err, ok := v.(error); ok && err != nil {
-			t.Fatal(err)
+func TestMain(m *testing.M) {
+	if err := runTestMain(m); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code, ok := err.(errCode)
+		if !ok {
+			code = 1
 		}
+		os.Exit(int(code))
 	}
+	os.Exit(0)
 }
+
+func runTestMain(m *testing.M) error {
+	flag.StringVar(&logFile, "fakes3.log", "", "Log file (temp file by default)")
+	flag.Parse()
+
+	var logOutput *os.File
+	var err error
+
+	if logFile == "" {
+		logOutput, err = ioutil.TempFile("", "gofakes3-*.log")
+	} else {
+		logOutput, err = os.Create(logFile)
+	}
+	if err != nil {
+		return err
+	}
+	defer logOutput.Close()
+
+	fmt.Fprintf(os.Stderr, "log output redirected to %q\n", logOutput.Name())
+	log.SetOutput(logOutput)
+
+	if code := m.Run(); code > 0 {
+		return errCode(code)
+	}
+	return nil
+}
+
+type errCode int
+
+func (e errCode) Error() string { return fmt.Sprintf("exit code %d", e) }

--- a/messages.go
+++ b/messages.go
@@ -103,6 +103,42 @@ type BucketPrefix struct {
 	Prefix string
 }
 
+type ObjectID struct {
+	Key string `xml:"Key"`
+
+	// Versions not supported in GoFakeS3 yet.
+	VersionID string `xml:"VersionId,omitempty" json:"VersionId,omitempty"`
+}
+
+type DeleteRequest struct {
+	Objects []ObjectID `xml:"Object"`
+
+	// Element to enable quiet mode for the request. When you add this element,
+	// you must set its value to true.
+	//
+	// By default, the operation uses verbose mode in which the response
+	// includes the result of deletion of each key in your request. In quiet
+	// mode the response includes only keys where the delete operation
+	// encountered an error. For a successful deletion, the operation does not
+	// return any information about the delete in the response body.
+	Quiet bool `xml:"Quiet"`
+}
+
+// DeleteResult contains the response from a multi delete operation.
+type DeleteResult struct {
+	Deleted []ObjectID    `xml:"Deleted"`
+	Error   []ErrorResult `xml:",omitempty"`
+}
+
+type ErrorResult struct {
+	XMLName   xml.Name  `xml:"Error"`
+	Key       string    `xml:"Key,omitempty"`
+	Code      ErrorCode `xml:"Code,omitempty"`
+	Message   string    `xml:"Message,omitempty"`
+	Resource  string    `xml:"Resource,omitempty"`
+	RequestID string    `xml:"RequestId,omitempty"`
+}
+
 type Object struct {
 	Metadata map[string]string
 	Size     int64

--- a/routing.go
+++ b/routing.go
@@ -78,7 +78,11 @@ func (g *GoFakeS3) routeBucket(bucket string, w http.ResponseWriter, r *http.Req
 	case "HEAD":
 		return g.headBucket(bucket, w, r)
 	case "POST":
-		return g.createObjectBrowserUpload(bucket, w, r)
+		if _, ok := r.URL.Query()["delete"]; ok {
+			return g.deleteMulti(bucket, w, r)
+		} else {
+			return g.createObjectBrowserUpload(bucket, w, r)
+		}
 	default:
 		return ErrMethodNotAllowed
 	}


### PR DESCRIPTION
I can't remember why exactly we needed this in our internal fork, but we did, so here it is!

I have also redirected the log in the testing output into a temporary file as I was having trouble seeing which of my tests was failing after I added this. I would like at some point to provide an interface to allow users of the GoFakeS3 package to be able to substitute the logging, but I didn't want to overload this PR any more than it already was.

An interesting thing that came up is that our internal fork started using the `s3` messages directly from the Go AWS SDK, which I think I'd like us to avoid doing here - if people use this package in their tests, they may have the SDK v1 or the SDK v2 included in their project already; I think we should stay agnostic and not use the SDK directly ourselves (except in tests).