### PR TITLE
Pluggable logger

### DIFF
--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -88,6 +88,7 @@ func run() error {
 		gofakes3.WithTimeSource(timeSource),
 		gofakes3.WithTimeSkewLimit(timeSkewLimit),
 		gofakes3.WithIntegrityCheck(!noIntegrity),
+		gofakes3.WithLogger(gofakes3.GlobalLog()),
 	)
 	return listenAndServe(host, faker.Server())
 }

--- a/cors.go
+++ b/cors.go
@@ -1,7 +1,6 @@
 package gofakes3
 
 import (
-	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -27,11 +26,12 @@ var (
 	bucketRewritePattern = regexp.MustCompile("(127.0.0.1:\\d{1,7})|(.localhost:\\d{1,7})|(localhost:\\d{1,7})")
 )
 
-type WithCORS struct {
-	r http.Handler
+type withCORS struct {
+	r   http.Handler
+	log Logger
 }
 
-func (s *WithCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *withCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, HEAD")
 	w.Header().Set("Access-Control-Allow-Headers", corsHeadersString)
@@ -44,14 +44,14 @@ func (s *WithCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// this is due to some inconsistencies in the AWS SDKs
 	bucket := bucketRewritePattern.ReplaceAllString(r.Host, "")
 	if len(bucket) > 0 {
-		log.Println("rewrite bucket ->", bucket)
+		s.log.Print(LogInfo, "rewrite bucket ->", bucket)
 		p := r.URL.Path
 		r.URL.Path = "/" + bucket
 		if p != "/" {
 			r.URL.Path += p
 		}
 	}
-	log.Println("=>", r.URL)
+	s.log.Print(LogInfo, "=>", r.URL)
 
 	s.r.ServeHTTP(w, r)
 }

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"math"
 	"net/http"
 	"strconv"
@@ -61,12 +60,13 @@ type GoFakeS3 struct {
 	metadataSizeLimit int
 	integrityCheck    bool
 	uploader          *uploader
+	log               Logger
 }
 
-// Setup a new fake object storage
+// New creates a new GoFakeS3 using the supplied Backend. Backends are pluggable.
+// Several Backend implementations ship with GoFakeS3, which can be found in the
+// gofakes3/backends package.
 func New(backend Backend, options ...Option) *GoFakeS3 {
-	log.Println("locals3 db created or opened")
-
 	s3 := &GoFakeS3{
 		storage:           backend,
 		timeSkew:          DefaultSkewLimit,
@@ -77,6 +77,9 @@ func New(backend Backend, options ...Option) *GoFakeS3 {
 	for _, opt := range options {
 		opt(s3)
 	}
+	if s3.log == nil {
+		s3.log = DiscardLog()
+	}
 	if s3.timeSource == nil {
 		s3.timeSource = DefaultTimeSource()
 	}
@@ -86,7 +89,7 @@ func New(backend Backend, options ...Option) *GoFakeS3 {
 
 // Create the AWS S3 API
 func (g *GoFakeS3) Server() http.Handler {
-	wc := &WithCORS{http.HandlerFunc(g.routeBase)}
+	wc := &withCORS{r: http.HandlerFunc(g.routeBase), log: g.log}
 
 	hf := func(w http.ResponseWriter, rq *http.Request) {
 		timeHdr := rq.Header.Get("x-amz-date")
@@ -111,7 +114,7 @@ func (g *GoFakeS3) Server() http.Handler {
 func (g *GoFakeS3) httpError(w http.ResponseWriter, r *http.Request, err error) {
 	resp := ensureErrorResponse(err, "") // FIXME: request id
 	if resp.ErrorCode() == ErrInternal {
-		log.Println(err)
+		g.log.Print(LogErr, err)
 	}
 
 	w.WriteHeader(resp.ErrorCode().Status())
@@ -122,7 +125,7 @@ func (g *GoFakeS3) httpError(w http.ResponseWriter, r *http.Request, err error) 
 		w.Write([]byte(xml.Header))
 		if err := g.xmlEncoder(w).Encode(resp); err != nil {
 			http.Error(w, err.Error(), http.StatusNotFound)
-			log.Println(err)
+			g.log.Print(LogErr, err)
 			return
 		}
 	}
@@ -156,12 +159,12 @@ func (g *GoFakeS3) getBuckets(w http.ResponseWriter, r *http.Request) error {
 
 // GetBucket lists the contents of a bucket.
 func (g *GoFakeS3) getBucket(bucketName string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("GET BUCKET")
+	g.log.Print(LogInfo, "GET BUCKET")
 
 	prefix := prefixFromQuery(r.URL.Query())
 
-	log.Println("bucketname:", bucketName)
-	log.Println("prefix    :", prefix)
+	g.log.Print(LogInfo, "bucketname:", bucketName)
+	g.log.Print(LogInfo, "prefix    :", prefix)
 
 	bucket, err := g.storage.GetBucket(bucketName, prefix)
 	if err != nil {
@@ -181,7 +184,7 @@ func (g *GoFakeS3) getBucket(bucketName string, w http.ResponseWriter, r *http.R
 
 // CreateBucket creates a new S3 bucket in the BoltDB storage.
 func (g *GoFakeS3) createBucket(bucket string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("CREATE BUCKET:", bucket)
+	g.log.Print(LogInfo, "CREATE BUCKET:", bucket)
 
 	if err := ValidateBucketName(bucket); err != nil {
 		return err
@@ -198,14 +201,14 @@ func (g *GoFakeS3) createBucket(bucket string, w http.ResponseWriter, r *http.Re
 
 // DeleteBucket creates a new S3 bucket in the BoltDB storage.
 func (g *GoFakeS3) deleteBucket(bucket string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("DELETE BUCKET:", bucket)
+	g.log.Print(LogInfo, "DELETE BUCKET:", bucket)
 	return g.storage.DeleteBucket(bucket)
 }
 
 // HeadBucket checks whether a bucket exists.
 func (g *GoFakeS3) headBucket(bucket string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("HEAD BUCKET", bucket)
-	log.Println("bucketname:", bucket)
+	g.log.Print(LogInfo, "HEAD BUCKET", bucket)
+	g.log.Print(LogInfo, "bucketname:", bucket)
 
 	if err := g.ensureBucketExists(bucket); err != nil {
 		return err
@@ -220,10 +223,9 @@ func (g *GoFakeS3) headBucket(bucket string, w http.ResponseWriter, r *http.Requ
 
 // GetObject retrievs a bucket object.
 func (g *GoFakeS3) getObject(bucket, object string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("GET OBJECT")
-
-	log.Println("Bucket:", bucket)
-	log.Println("└── Object:", object)
+	g.log.Print(LogInfo, "GET OBJECT")
+	g.log.Print(LogInfo, "Bucket:", bucket)
+	g.log.Print(LogInfo, "└── Object:", object)
 
 	obj, err := g.storage.GetObject(bucket, object)
 	if err != nil {
@@ -250,7 +252,7 @@ func (g *GoFakeS3) getObject(bucket, object string, w http.ResponseWriter, r *ht
 
 // CreateObject (Browser Upload) creates a new S3 object.
 func (g *GoFakeS3) createObjectBrowserUpload(bucket string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("CREATE OBJECT THROUGH BROWSER UPLOAD")
+	g.log.Print(LogInfo, "CREATE OBJECT THROUGH BROWSER UPLOAD")
 
 	const _24MB = (1 << 20) * 24 // maximum amount of memory before temp files are used
 	if err := r.ParseMultipartForm(_24MB); nil != err {
@@ -263,8 +265,8 @@ func (g *GoFakeS3) createObjectBrowserUpload(bucket string, w http.ResponseWrite
 	}
 	key := keyValues[0]
 
-	log.Println("(BUC)", bucket)
-	log.Println("(KEY)", key)
+	g.log.Print(LogInfo, "(BUC)", bucket)
+	g.log.Print(LogInfo, "(KEY)", key)
 
 	fileValues := r.MultipartForm.File["file"]
 	if len(fileValues) != 1 {
@@ -303,7 +305,7 @@ func (g *GoFakeS3) createObjectBrowserUpload(bucket string, w http.ResponseWrite
 
 // CreateObject creates a new S3 object.
 func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r *http.Request) (err error) {
-	log.Println("CREATE OBJECT:", bucket, object)
+	g.log.Print(LogInfo, "CREATE OBJECT:", bucket, object)
 
 	meta, err := metadataHeaders(r.Header, g.timeSource.Now(), g.metadataSizeLimit)
 	if err != nil {
@@ -348,7 +350,7 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 
 // deleteObject deletes a S3 object from the bucket.
 func (g *GoFakeS3) deleteObject(bucket, object string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("DELETE:", bucket, object)
+	g.log.Print(LogInfo, "DELETE:", bucket, object)
 	if err := g.storage.DeleteObject(bucket, object); err != nil {
 		return err
 	}
@@ -360,7 +362,7 @@ func (g *GoFakeS3) deleteObject(bucket, object string, w http.ResponseWriter, r 
 // deleteMulti deletes multiple S3 objects from the bucket.
 // https://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html
 func (g *GoFakeS3) deleteMulti(bucket string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("delete multi", bucket)
+	g.log.Print(LogInfo, "delete multi", bucket)
 
 	var in DeleteRequest
 
@@ -396,10 +398,10 @@ func (g *GoFakeS3) deleteMulti(bucket string, w http.ResponseWriter, r *http.Req
 
 // HeadObject retrieves only meta information of an object and not the whole.
 func (g *GoFakeS3) headObject(bucket, object string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("HEAD OBJECT")
+	g.log.Print(LogInfo, "HEAD OBJECT")
 
-	log.Println("Bucket:", bucket)
-	log.Println("└── Object:", object)
+	g.log.Print(LogInfo, "Bucket:", bucket)
+	g.log.Print(LogInfo, "└── Object:", object)
 
 	obj, err := g.storage.HeadObject(bucket, object)
 	if err != nil {
@@ -423,7 +425,7 @@ func (g *GoFakeS3) headObject(bucket, object string, w http.ResponseWriter, r *h
 }
 
 func (g *GoFakeS3) initiateMultipartUpload(bucket, object string, w http.ResponseWriter, r *http.Request) error {
-	log.Println("initiate multipart upload", bucket, object)
+	g.log.Print(LogInfo, "initiate multipart upload", bucket, object)
 
 	meta, err := metadataHeaders(r.Header, g.timeSource.Now(), g.metadataSizeLimit)
 	if err != nil {
@@ -446,7 +448,7 @@ func (g *GoFakeS3) initiateMultipartUpload(bucket, object string, w http.Respons
 // 	part. There is no size limit on the last part of your multipart upload.
 //
 func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID UploadID, w http.ResponseWriter, r *http.Request) error {
-	log.Println("put multipart upload", bucket, object, uploadID)
+	g.log.Print(LogInfo, "put multipart upload", bucket, object, uploadID)
 
 	partNumber, err := strconv.ParseInt(r.URL.Query().Get("partNumber"), 10, 0)
 	if err != nil || partNumber <= 0 || partNumber > MaxUploadPartNumber {
@@ -500,13 +502,13 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 }
 
 func (g *GoFakeS3) abortMultipartUpload(bucket, object string, uploadID UploadID, w http.ResponseWriter, r *http.Request) error {
-	log.Println("abort multipart upload", bucket, object, uploadID)
+	g.log.Print(LogInfo, "abort multipart upload", bucket, object, uploadID)
 	_, err := g.uploader.Complete(bucket, object, uploadID)
 	return err
 }
 
 func (g *GoFakeS3) completeMultipartUpload(bucket, object string, uploadID UploadID, w http.ResponseWriter, r *http.Request) error {
-	log.Println("complete multipart upload", bucket, object, uploadID)
+	g.log.Print(LogInfo, "complete multipart upload", bucket, object, uploadID)
 
 	body, err := ioutil.ReadAll(r.Body)
 	defer r.Body.Close()

--- a/init_test.go
+++ b/init_test.go
@@ -173,8 +173,9 @@ func newTestServer(t *testing.T, opts ...testServerOption) *testServer {
 		gofakes3.WithTimeSource(ts.TimeSourceAdvancer),
 		gofakes3.WithTimeSkewLimit(0),
 
-		// TestMain wires the stdlib's global logger up to a file, so we should just use that.
-		gofakes3.WithLogger(gofakes3.GlobalLog()),
+		// TestMain wires the stdlib's global logger up to a file already,
+		// which this takes advantage of:
+		gofakes3.WithGlobalLog(),
 	)
 	ts.server = httptest.NewServer(ts.GoFakeS3.Server())
 

--- a/init_test.go
+++ b/init_test.go
@@ -172,6 +172,9 @@ func newTestServer(t *testing.T, opts ...testServerOption) *testServer {
 	ts.GoFakeS3 = gofakes3.New(ts.backend,
 		gofakes3.WithTimeSource(ts.TimeSourceAdvancer),
 		gofakes3.WithTimeSkewLimit(0),
+
+		// TestMain wires the stdlib's global logger up to a file, so we should just use that.
+		gofakes3.WithLogger(gofakes3.NewGlobalLog()),
 	)
 	ts.server = httptest.NewServer(ts.GoFakeS3.Server())
 

--- a/init_test.go
+++ b/init_test.go
@@ -174,7 +174,7 @@ func newTestServer(t *testing.T, opts ...testServerOption) *testServer {
 		gofakes3.WithTimeSkewLimit(0),
 
 		// TestMain wires the stdlib's global logger up to a file, so we should just use that.
-		gofakes3.WithLogger(gofakes3.NewGlobalLog()),
+		gofakes3.WithLogger(gofakes3.GlobalLog()),
 	)
 	ts.server = httptest.NewServer(ts.GoFakeS3.Server())
 

--- a/log.go
+++ b/log.go
@@ -1,0 +1,110 @@
+package gofakes3
+
+import "log"
+
+type LogLevel string
+
+const (
+	LogErr  LogLevel = "ERR"
+	LogWarn LogLevel = "WARN"
+	LogInfo LogLevel = "INFO"
+)
+
+// Logger provides a very minimal target for logging implementations to hit to
+// allow arbitrary logging dependencies to be used with GoFakeS3.
+//
+// Only an interface to the standard library's log package is provided with
+// GoFakeS3, other libraries will require an adapter. Adapters are trivial to
+// write.
+//
+// For zap:
+//
+//	type LogrusLog struct {
+//		log *zap.Logger
+//	}
+//
+//	func (l LogrusLog) Print(level LogLevel, v ...interface{}) {
+//		switch level {
+//		case gofakes3.LogErr:
+//			l.log.Error(fmt.Sprint(v...))
+//		case gofakes3.LogWarn:
+//			l.log.Warn(fmt.Sprint(v...))
+//		case gofakes3.LogInfo:
+//			l.log.Info(fmt.Sprint(v...))
+//		default:
+//			panic("unknown level")
+//		}
+//	}
+//
+//
+// For logrus:
+//
+//	type LogrusLog struct {
+//		log *logrus.Logger
+//	}
+//
+//	func (l LogrusLog) Print(level LogLevel, v ...interface{}) {
+//		switch level {
+//		case gofakes3.LogErr:
+//			l.log.Errorln(v...)
+//		case gofakes3.LogWarn:
+//			l.log.Warnln(v...)
+//		case gofakes3.LogInfo:
+//			l.log.Infoln(v...)
+//		default:
+//			panic("unknown level")
+//		}
+//	}
+//
+type Logger interface {
+	Print(level LogLevel, v ...interface{})
+}
+
+type StdLog struct {
+	log    func(v ...interface{})
+	levels map[LogLevel]bool
+}
+
+// NewGlobalLog creates a Logger that uses the global log.Println() function.
+//
+// All levels are reported by default. If you pass levels to this function,
+// it will act as a level whitelist.
+func NewGlobalLog(levels ...LogLevel) *StdLog {
+	return newStdLog(log.Println, levels...)
+}
+
+// NewStdLog creates a Logger that uses the stdlib's log.Logger type.
+//
+// All levels are reported by default. If you pass levels to this function,
+// it will act as a level whitelist.
+func NewStdLog(log *log.Logger, levels ...LogLevel) *StdLog {
+	return newStdLog(log.Println, levels...)
+}
+
+func newStdLog(log func(v ...interface{}), levels ...LogLevel) *StdLog {
+	sl := &StdLog{log: log}
+	if len(levels) > 0 {
+		sl.levels = map[LogLevel]bool{}
+		for _, lv := range levels {
+			sl.levels[lv] = true
+		}
+	}
+	return sl
+}
+
+func (s StdLog) Print(level LogLevel, v ...interface{}) {
+	if s.levels == nil || s.levels[level] {
+		v = append(v, nil)
+		copy(v[1:], v)
+		v[0] = level
+		s.log(v...)
+	}
+}
+
+func DiscardLog() Logger {
+	return &discardLog{}
+}
+
+type discardLog struct{}
+
+func (d discardLog) Print(level LogLevel, v ...interface{}) {}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,41 @@
+package gofakes3
+
+import (
+	"bytes"
+	"log"
+	"testing"
+)
+
+func TestStdLog(t *testing.T) {
+	var buf bytes.Buffer
+	std := log.New(&buf, "", 0)
+	l := StdLog(std)
+
+	l.Print(LogErr, "yep1", 1)
+	l.Print(LogErr, "yep2", 2)
+	if buf.String() != "ERR yep1 1\nERR yep2 2\n" {
+		t.Fatal()
+	}
+}
+
+func TestStdLogLevels(t *testing.T) {
+	var buf bytes.Buffer
+	std := log.New(&buf, "", 0)
+	l := StdLog(std, LogErr)
+
+	l.Print(LogErr, "yep1", 1)
+	l.Print(LogWarn, "yep2", 2)
+	l.Print(LogInfo, "yep3", 3)
+	if buf.String() != "ERR yep1 1\n" {
+		t.Fatal()
+	}
+}
+
+func TestDiscardLog(t *testing.T) {
+	d := DiscardLog()
+
+	// if it doesn't panic, that's all we can test!
+	d.Print(LogErr, "yep1", 1)
+	d.Print(LogWarn, "yep2", 2)
+	d.Print(LogInfo, "yep3", 3)
+}

--- a/option.go
+++ b/option.go
@@ -37,3 +37,9 @@ func WithMetadataSizeLimit(size int) Option {
 func WithIntegrityCheck(check bool) Option {
 	return func(g *GoFakeS3) { g.integrityCheck = check }
 }
+
+// WithLogger allows you to supply a logger to GoFakeS3 for debugging/tracing.
+// logger may be nil.
+func WithLogger(logger Logger) Option {
+	return func(g *GoFakeS3) { g.log = logger }
+}

--- a/option.go
+++ b/option.go
@@ -43,3 +43,9 @@ func WithIntegrityCheck(check bool) Option {
 func WithLogger(logger Logger) Option {
 	return func(g *GoFakeS3) { g.log = logger }
 }
+
+// WithGlobalLog configures gofakes3 to use GlobalLog() for logging, which uses
+// the standard library's log.Println() call to log messages.
+func WithGlobalLog() Option {
+	return WithLogger(GlobalLog())
+}


### PR DESCRIPTION
Here's a refreshingly simple one! A couple of the projects I'm integrating gofakes3 with use different loggers to the standard library's log. I've got a useful little bit of copy-pasta for situations like this which I've popped in to this PR (`log.go`). It lets you swap the log out and adapt whatever your project happens to be using easily, and fall back on the standard library's logger even more easily. The CLI tool and tester should both still work exactly as before: the CLI will still log to console, and the tester will still redirect the log to a file. Using gofakes3 directly will no longer generate log output by default though: you have to opt in to the old behaviour using `gofakes3.WithGlobalLog()`.

Go 2 will hopefully convert log.Logger to an interface, which would obviate the need for all this if log library authors get on board and implement it, but we're not there yet unfortunately: https://github.com/golang/go/issues/13182