### PR TITLE
Bucket rewriting switch

### DIFF
--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -31,6 +31,7 @@ type fakeS3Flags struct {
 	initialBucket string
 	fixedTimeStr  string
 	noIntegrity   bool
+	hostBucket    bool
 
 	boltDb         string
 	directFsPath   string
@@ -45,6 +46,7 @@ func (f *fakeS3Flags) attach(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&f.fixedTimeStr, "time", "", "RFC3339 format. If passed, the server's clock will always see this time; does not affect existing stored dates.")
 	flagSet.StringVar(&f.initialBucket, "initialbucket", "", "If passed, this bucket will be created on startup if it does not already exist.")
 	flagSet.BoolVar(&f.noIntegrity, "no-integrity", false, "Pass this flag to disable Content-MD5 validation when uploading.")
+	flagSet.BoolVar(&f.hostBucket, "hostbucket", false, "If passed, the bucket name will be extracted from the first segment of the hostname, rather than the first part of the URL path.")
 
 	// Backend specific:
 	flagSet.StringVar(&f.backendKind, "backend", "", "Backend to use to store data (memory, bolt, directfs, fs)")
@@ -181,6 +183,7 @@ func run() error {
 		gofakes3.WithTimeSkewLimit(timeSkewLimit),
 		gofakes3.WithTimeSource(timeSource),
 		gofakes3.WithLogger(gofakes3.GlobalLog()),
+		gofakes3.WithHostBucket(hostBucket),
 	)
 
 	return listenAndServe(values.host, faker.Server())

--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -183,7 +183,7 @@ func run() error {
 		gofakes3.WithTimeSkewLimit(timeSkewLimit),
 		gofakes3.WithTimeSource(timeSource),
 		gofakes3.WithLogger(gofakes3.GlobalLog()),
-		gofakes3.WithHostBucket(hostBucket),
+		gofakes3.WithHostBucket(values.hostBucket),
 	)
 
 	return listenAndServe(values.host, faker.Server())

--- a/cors.go
+++ b/cors.go
@@ -2,7 +2,6 @@ package gofakes3
 
 import (
 	"net/http"
-	"regexp"
 	"strings"
 )
 
@@ -22,8 +21,6 @@ var (
 		"x-amz-meta-to",
 	}
 	corsHeadersString = strings.Join(corsHeaders, ", ")
-
-	bucketRewritePattern = regexp.MustCompile("(127.0.0.1:\\d{1,7})|(.localhost:\\d{1,7})|(localhost:\\d{1,7})")
 )
 
 type withCORS struct {
@@ -39,19 +36,6 @@ func (s *withCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "OPTIONS" {
 		return
 	}
-
-	// Bucket name rewriting
-	// this is due to some inconsistencies in the AWS SDKs
-	bucket := bucketRewritePattern.ReplaceAllString(r.Host, "")
-	if len(bucket) > 0 {
-		s.log.Print(LogInfo, "rewrite bucket ->", bucket)
-		p := r.URL.Path
-		r.URL.Path = "/" + bucket
-		if p != "/" {
-			r.URL.Path += p
-		}
-	}
-	s.log.Print(LogInfo, "=>", r.URL)
 
 	s.r.ServeHTTP(w, r)
 }

--- a/option.go
+++ b/option.go
@@ -55,3 +55,13 @@ func WithGlobalLog() Option {
 func WithRequestID(id uint64) Option {
 	return func(g *GoFakeS3) { g.requestID = id }
 }
+
+// WithHostBucket enables or disables bucket rewriting in the router.
+// If active, the URL 'http://mybucket.localhost/object' will be routed
+// as if the URL path was '/mybucket/object'.
+//
+// See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
+// for details.
+func WithHostBucket(enabled bool) Option {
+	return func(g *GoFakeS3) { g.hostBucket = enabled }
+}


### PR DESCRIPTION
I have been a bit stumped on this one. We removed the bucket rewriting from our internal fork for some reason a while ago, but I wasn't sure why. I couldn't quite work out what problem it solves, but just knew that it wouldn't have been there in the first place if it didn't solve a problem, so I was reluctant to try to tackle it until I understood more. I think I may have found some details that explain it, but I'll need your help sanity-checking my thinking here as I could be way off target!

I came across this in the documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
It mentions that there are two ways you can specify the bucket, either in the URL path or in the host name. I guessed (possibly wrongly) that this is the rationale for the bucket rewriting code. I figure in a testing context, your domain could be anything, and you could favour either method. S3 has the luxury of assuming if the hostname follows a similar format to `<bucket>.<region>.amazonaws.com`, it must contain the bucket, but it looks to me like we don't really have that luxury as the user could set the hostname to be anything at all, so I can't see a way to reliably detect when you're using virtualhost-style URLs or path-style. I've created this PR with an option to turn that detection on for all requests or off for all requests, but as I was wrapping it up I started to doubt that it was the right approach so I thought I should push it up here anyway as conversation starter.

I branched this off the logging branch by accident, but I'll fix that up later if it turns out this is worth pursuing.

The update I made to the README the other week actually doesn't work in light of this; I was basing it off what I knew to work with our internal fork without realising that the bucket rewriting affects the interpretation of the URL and that code was removed from our fork. Sorry about that, especially to any user who may have been misled by my README change! 😳 