### PR TITLE
Fix "multiple calls to WriteHeader" bug

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -121,7 +121,6 @@ func (g *GoFakeS3) httpError(w http.ResponseWriter, r *http.Request, err error) 
 
 		w.Write([]byte(xml.Header))
 		if err := g.xmlEncoder(w).Encode(resp); err != nil {
-			http.Error(w, err.Error(), http.StatusNotFound)
 			log.Println(err)
 			return
 		}

--- a/gofakes3_internal_test.go
+++ b/gofakes3_internal_test.go
@@ -1,0 +1,52 @@
+package gofakes3
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHttpError(t *testing.T) {
+	var g GoFakeS3
+	rq := httptest.NewRequest("GET", "/", nil)
+	rs := httptest.NewRecorder()
+	g.httpError(rs, rq, ErrNoSuchBucket)
+	if rs.Code != 404 {
+		t.Fatal()
+	}
+	if rs.Body.Len() == 0 {
+		t.Fatal()
+	}
+	var resp ErrorResponse
+	if err := xml.Unmarshal(rs.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Code != ErrNoSuchBucket {
+		t.Fatal()
+	}
+}
+
+func TestHttpErrorWriteFailure(t *testing.T) {
+	// FIXME: with a pluggable logger, we can intercept the log message to
+	// verify the write error is handled.
+	var g GoFakeS3
+	rq := httptest.NewRequest("GET", "/", nil)
+	rs := httptest.NewRecorder()
+	g.httpError(&failingResponseWriter{rs}, rq, ErrNoSuchBucket)
+	if rs.Code != 404 {
+		t.Fatal()
+	}
+	if rs.Body.Len() != 0 {
+		t.Fatal()
+	}
+}
+
+type failingResponseWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (w *failingResponseWriter) Write(buf []byte) (n int, err error) {
+	return 0, fmt.Errorf("nope")
+}


### PR DESCRIPTION
Sorry for all the PR spam; I ran into a small bug where the error handler attempts to call WriteHeader twice in certain circumstances.

I tried to add some test cases to prevent regression, but it proved to be quite tricky. The pluggable logger might make it easier to intercept the log messages without disrupting other tests, but I didn't want to mess with that here. The test cases I've added here are not useless though, they still test something meaningful.