### PR TITLE
GetObject Range header support

### DIFF
--- a/awscli_test.go
+++ b/awscli_test.go
@@ -104,6 +104,11 @@ func TestCLIDownload(t *testing.T) {
 	}{
 		{in: nil},
 		{in: source[:1]},
+
+		// FIXME: Beyond a certain size, the AWS client switches to using range
+		// requests and downloads several parts in parallel. This takes a stab
+		// at what that size is, but it isn't an especially robust way to
+		// determine what the spill point is:
 		{in: source[:1000000]},
 		{in: source[:10000000]},
 		{in: source[:100000000]},

--- a/awscli_test.go
+++ b/awscli_test.go
@@ -97,7 +97,7 @@ func TestCLIRmMulti(t *testing.T) {
 
 func TestCLIDownload(t *testing.T) {
 	// NOTE: this must be set to the largest value you plan to test in the test cases.
-	var source = randomFileBody(1000000000)
+	var source = randomFileBody(100000000)
 
 	for _, tc := range []struct {
 		in []byte

--- a/backend.go
+++ b/backend.go
@@ -51,7 +51,7 @@ type Backend interface {
 	//
 	// If the returned Object is not nil, you MUST call Object.Contents.Close(),
 	// otherwise you will leak resources.
-	GetObject(bucketName, objectName string) (*Object, error)
+	GetObject(bucketName, objectName string, rnge ObjectRangeRequest) (*Object, error)
 
 	// DeleteObject deletes an object from the bucket.
 	//

--- a/backend.go
+++ b/backend.go
@@ -51,7 +51,11 @@ type Backend interface {
 	//
 	// If the returned Object is not nil, you MUST call Object.Contents.Close(),
 	// otherwise you will leak resources.
-	GetObject(bucketName, objectName string, rnge ObjectRangeRequest) (*Object, error)
+	//
+	// If rnge is nil, it is assumed you want the entire object. If rnge is not
+	// nil, but the underlying backend does not support range requests,
+	// implementers MUST return ErrNotImplemented.
+	GetObject(bucketName, objectName string, rnge *ObjectRangeRequest) (*Object, error)
 
 	// DeleteObject deletes an object from the bucket.
 	//

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -240,7 +240,7 @@ func (db *Backend) BucketExists(name string) (exists bool, err error) {
 }
 
 func (db *Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, error) {
-	obj, err := db.GetObject(bucketName, objectName)
+	obj, err := db.GetObject(bucketName, objectName, gofakes3.ObjectRangeRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (db *Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, 
 	return obj, nil
 }
 
-func (db *Backend) GetObject(bucketName, objectName string) (*gofakes3.Object, error) {
+func (db *Backend) GetObject(bucketName, objectName string, rnge gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
 	var t boltObject
 
 	err := db.bolt.View(func(tx *bolt.Tx) error {
@@ -273,7 +273,7 @@ func (db *Backend) GetObject(bucketName, objectName string) (*gofakes3.Object, e
 		return nil, err
 	}
 
-	return t.Object(), nil
+	return t.Object(rnge), nil
 }
 
 func (db *Backend) PutObject(bucketName, objectName string, meta map[string]string, input io.Reader, size int64) error {

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -240,7 +240,7 @@ func (db *Backend) BucketExists(name string) (exists bool, err error) {
 }
 
 func (db *Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, error) {
-	obj, err := db.GetObject(bucketName, objectName, gofakes3.ObjectRangeRequest{})
+	obj, err := db.GetObject(bucketName, objectName, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (db *Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, 
 	return obj, nil
 }
 
-func (db *Backend) GetObject(bucketName, objectName string, rnge gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
+func (db *Backend) GetObject(bucketName, objectName string, rnge *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
 	var t boltObject
 
 	err := db.bolt.View(func(tx *bolt.Tx) error {

--- a/backend/s3bolt/schema.go
+++ b/backend/s3bolt/schema.go
@@ -27,10 +27,12 @@ type boltObject struct {
 	Hash         []byte
 }
 
-func (b *boltObject) Object(rnge gofakes3.ObjectRangeRequest) *gofakes3.Object {
-	rngeRs := rnge.Range(b.Size)
+func (b *boltObject) Object(rnge *gofakes3.ObjectRangeRequest) *gofakes3.Object {
 	data := b.Contents
-	if !rnge.IsZero() {
+
+	var rngeRs *gofakes3.ObjectRange
+	if rnge != nil {
+		rngeRs = rnge.Range(b.Size)
 		data = data[rngeRs.Start : rngeRs.Start+rngeRs.Length]
 	}
 

--- a/backend/s3bolt/schema.go
+++ b/backend/s3bolt/schema.go
@@ -27,11 +27,18 @@ type boltObject struct {
 	Hash         []byte
 }
 
-func (b *boltObject) Object() *gofakes3.Object {
+func (b *boltObject) Object(rnge gofakes3.ObjectRangeRequest) *gofakes3.Object {
+	rngeRs := rnge.Range(b.Size)
+	data := b.Contents
+	if !rnge.IsZero() {
+		data = data[rngeRs.Start : rngeRs.Start+rngeRs.Length]
+	}
+
 	return &gofakes3.Object{
 		Metadata: b.Metadata,
 		Size:     b.Size,
-		Contents: readerWithDummyCloser{bytes.NewReader(b.Contents)},
+		Contents: readerWithDummyCloser{bytes.NewReader(data)},
+		Range:    rngeRs,
 		Hash:     b.Hash,
 	}
 }

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -144,7 +144,7 @@ func (db *Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, 
 	}, nil
 }
 
-func (db *Backend) GetObject(bucketName, objectName string) (*gofakes3.Object, error) {
+func (db *Backend) GetObject(bucketName, objectName string, rnge gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
@@ -158,14 +158,22 @@ func (db *Backend) GetObject(bucketName, objectName string) (*gofakes3.Object, e
 		return nil, gofakes3.KeyNotFound(objectName)
 	}
 
+	sz := int64(len(obj.data))
+	rngeRs := rnge.Range(sz)
+	data := obj.data
+	if !rnge.IsZero() {
+		data = data[rngeRs.Start : rngeRs.Start+rngeRs.Length]
+	}
+
 	return &gofakes3.Object{
 		Hash:     obj.hash,
 		Metadata: obj.metadata,
-		Size:     int64(len(obj.data)),
+		Size:     sz,
+		Range:    rngeRs,
 
 		// The data slice should be completely replaced if the bucket item is edited, so
 		// it should be safe to return the data slice directly.
-		Contents: readerWithDummyCloser{bytes.NewReader(obj.data)},
+		Contents: readerWithDummyCloser{bytes.NewReader(data)},
 	}, nil
 }
 

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -144,7 +144,7 @@ func (db *Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, 
 	}, nil
 }
 
-func (db *Backend) GetObject(bucketName, objectName string, rnge gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
+func (db *Backend) GetObject(bucketName, objectName string, rnge *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
@@ -159,9 +159,11 @@ func (db *Backend) GetObject(bucketName, objectName string, rnge gofakes3.Object
 	}
 
 	sz := int64(len(obj.data))
-	rngeRs := rnge.Range(sz)
 	data := obj.data
-	if !rnge.IsZero() {
+
+	var rngeRs *gofakes3.ObjectRange
+	if rnge != nil {
+		rngeRs = rnge.Range(sz)
 		data = data[rngeRs.Start : rngeRs.Start+rngeRs.Length]
 	}
 

--- a/error.go
+++ b/error.go
@@ -37,12 +37,13 @@ const (
 	// only for reference.
 	ErrInlineDataTooLarge ErrorCode = "InlineDataTooLarge"
 
-	// The Content-MD5 you specified is not valid.
-	ErrInvalidDigest ErrorCode = "InvalidDigest"
-
 	// https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
 	ErrInvalidBucketName ErrorCode = "InvalidBucketName"
 
+	// The Content-MD5 you specified is not valid.
+	ErrInvalidDigest ErrorCode = "InvalidDigest"
+
+	ErrInvalidRange         ErrorCode = "InvalidRange"
 	ErrKeyTooLong           ErrorCode = "KeyTooLongError" // This is not a typo: Error is part of the string, but redundant in the constant name
 	ErrMalformedPOSTRequest ErrorCode = "MalformedPOSTRequest"
 
@@ -214,6 +215,9 @@ func (e ErrorCode) Status() int {
 
 	case ErrRequestTimeTooSkewed:
 		return http.StatusForbidden
+
+	case ErrInvalidRange:
+		return http.StatusRequestedRangeNotSatisfiable
 
 	case ErrNoSuchBucket,
 		ErrNoSuchKey,

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -225,8 +225,8 @@ func (g *GoFakeS3) getObject(bucket, object string, w http.ResponseWriter, r *ht
 	log.Println("Bucket:", bucket)
 	log.Println("└── Object:", object)
 
-	var rnge ObjectRangeRequest
-	if err := rnge.parseHeader(r.Header.Get("Range")); err != nil {
+	rnge, err := parseRangeHeader(r.Header.Get("Range"))
+	if err != nil {
 		return err
 	}
 

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -196,7 +196,8 @@ func (g *GoFakeS3) createBucket(bucket string, w http.ResponseWriter, r *http.Re
 	return nil
 }
 
-// DeleteBucket creates a new S3 bucket in the BoltDB storage.
+// DeleteBucket deletes the bucket in the underlying backend, if and only if it
+// contains no items.
 func (g *GoFakeS3) deleteBucket(bucket string, w http.ResponseWriter, r *http.Request) error {
 	log.Println("DELETE BUCKET:", bucket)
 	return g.storage.DeleteBucket(bucket)

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -248,6 +248,7 @@ func (g *GoFakeS3) getObject(bucket, object string, w http.ResponseWriter, r *ht
 	w.Header().Set("Last-Modified", formatHeaderTime(g.timeSource.Now()))
 	w.Header().Set("ETag", "\""+hex.EncodeToString(obj.Hash)+"\"")
 	w.Header().Set("Server", "AmazonS3")
+	w.Header().Set("Accept-Ranges", "bytes")
 
 	if _, err := io.Copy(w, obj.Contents); err != nil {
 		return err
@@ -425,6 +426,7 @@ func (g *GoFakeS3) headObject(bucket, object string, w http.ResponseWriter, r *h
 	w.Header().Set("Server", "AmazonS3")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", obj.Size))
 	w.Header().Set("Connection", "close")
+	w.Header().Set("Accept-Ranges", "bytes")
 	w.Write([]byte{})
 
 	return nil

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -86,17 +86,17 @@ func TestListBuckets(t *testing.T) {
 
 	assertBuckets()
 
-	ts.createBucket("test")
+	ts.backendCreateBucket("test")
 	assertBuckets("test")
 	assertBucketTime("test", defaultDate)
 
-	ts.createBucket("test2")
+	ts.backendCreateBucket("test2")
 	assertBuckets("test", "test2")
 	assertBucketTime("test2", defaultDate)
 
 	ts.Advance(1 * time.Minute)
 
-	ts.createBucket("test3")
+	ts.backendCreateBucket("test3")
 	assertBuckets("test", "test2", "test3")
 
 	assertBucketTime("test", defaultDate)
@@ -115,7 +115,7 @@ func TestCreateObject(t *testing.T) {
 		Body:   bytes.NewReader([]byte("hello")),
 	}))
 
-	obj := ts.objectAsString(defaultBucket, "object", nil)
+	obj := ts.backendGetString(defaultBucket, "object", nil)
 	if obj != "hello" {
 		t.Fatal("object creation failed")
 	}
@@ -150,7 +150,7 @@ func TestCreateObjectMD5(t *testing.T) {
 		}
 	}
 
-	if ts.objectExists(defaultBucket, "invalid") {
+	if ts.backendObjectExists(defaultBucket, "invalid") {
 		t.Fatal("unexpected object")
 	}
 }
@@ -178,9 +178,9 @@ func TestDeleteMulti(t *testing.T) {
 		defer ts.Close()
 		svc := ts.s3Client()
 
-		ts.putString(defaultBucket, "foo", nil, "one")
-		ts.putString(defaultBucket, "bar", nil, "two")
-		ts.putString(defaultBucket, "baz", nil, "three")
+		ts.backendPutString(defaultBucket, "foo", nil, "one")
+		ts.backendPutString(defaultBucket, "bar", nil, "two")
+		ts.backendPutString(defaultBucket, "baz", nil, "three")
 
 		rs, err := svc.DeleteObjects(&s3.DeleteObjectsInput{
 			Bucket: aws.String(defaultBucket),
@@ -200,9 +200,9 @@ func TestDeleteMulti(t *testing.T) {
 		defer ts.Close()
 		svc := ts.s3Client()
 
-		ts.putString(defaultBucket, "foo", nil, "one")
-		ts.putString(defaultBucket, "bar", nil, "two")
-		ts.putString(defaultBucket, "baz", nil, "three")
+		ts.backendPutString(defaultBucket, "foo", nil, "one")
+		ts.backendPutString(defaultBucket, "bar", nil, "two")
+		ts.backendPutString(defaultBucket, "baz", nil, "three")
 
 		rs, err := svc.DeleteObjects(&s3.DeleteObjectsInput{
 			Bucket: aws.String(defaultBucket),

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -115,7 +115,7 @@ func TestCreateObject(t *testing.T) {
 		Body:   bytes.NewReader([]byte("hello")),
 	}))
 
-	obj := ts.objectAsString(defaultBucket, "object")
+	obj := ts.objectAsString(defaultBucket, "object", nil)
 	if obj != "hello" {
 		t.Fatal("object creation failed")
 	}

--- a/init_test.go
+++ b/init_test.go
@@ -211,9 +211,12 @@ func (ts *testServer) putString(bucket, key string, meta map[string]string, in s
 	ts.OK(ts.backend.PutObject(bucket, key, meta, strings.NewReader(in), int64(len(in))))
 }
 
-func (ts *testServer) objectAsString(bucket, key string) string {
+func (ts *testServer) objectAsString(bucket, key string, rnge *gofakes3.ObjectRangeRequest) string {
 	ts.Helper()
-	obj, err := ts.backend.GetObject(bucket, key)
+	if rnge == nil {
+		rnge = &gofakes3.ObjectRangeRequest{}
+	}
+	obj, err := ts.backend.GetObject(bucket, key, *rnge)
 	ts.OK(err)
 
 	defer obj.Contents.Close()
@@ -557,7 +560,7 @@ func (ts *testServer) assertListMultipartUploads(
 func (ts *testServer) assertObject(bucket string, object string, meta map[string]string, contents interface{}) {
 	ts.Helper()
 
-	obj, err := ts.backend.GetObject(bucket, object)
+	obj, err := ts.backend.GetObject(bucket, object, gofakes3.ObjectRangeRequest{})
 	ts.OK(err)
 	defer obj.Contents.Close()
 

--- a/init_test.go
+++ b/init_test.go
@@ -218,10 +218,7 @@ func (ts *testServer) backendPutBytes(bucket, key string, meta map[string]string
 
 func (ts *testServer) backendGetString(bucket, key string, rnge *gofakes3.ObjectRangeRequest) string {
 	ts.Helper()
-	if rnge == nil {
-		rnge = &gofakes3.ObjectRangeRequest{}
-	}
-	obj, err := ts.backend.GetObject(bucket, key, *rnge)
+	obj, err := ts.backend.GetObject(bucket, key, rnge)
 	ts.OK(err)
 
 	defer obj.Contents.Close()
@@ -565,7 +562,7 @@ func (ts *testServer) assertListMultipartUploads(
 func (ts *testServer) assertObject(bucket string, object string, meta map[string]string, contents interface{}) {
 	ts.Helper()
 
-	obj, err := ts.backend.GetObject(bucket, object, gofakes3.ObjectRangeRequest{})
+	obj, err := ts.backend.GetObject(bucket, object, nil)
 	ts.OK(err)
 	defer obj.Contents.Close()
 

--- a/init_test.go
+++ b/init_test.go
@@ -186,14 +186,14 @@ func (ts *testServer) url(url string) string {
 	return fmt.Sprintf("%s/%s", ts.server.URL, strings.TrimLeft(url, "/"))
 }
 
-func (ts *testServer) createBucket(bucket string) {
+func (ts *testServer) backendCreateBucket(bucket string) {
 	ts.Helper()
 	if err := ts.backend.CreateBucket(bucket); err != nil {
 		ts.Fatal("create bucket failed", err)
 	}
 }
 
-func (ts *testServer) objectExists(bucket, key string) bool {
+func (ts *testServer) backendObjectExists(bucket, key string) bool {
 	ts.Helper()
 	obj, err := ts.backend.HeadObject(bucket, key)
 	if err != nil {
@@ -206,12 +206,17 @@ func (ts *testServer) objectExists(bucket, key string) bool {
 	return obj != nil
 }
 
-func (ts *testServer) putString(bucket, key string, meta map[string]string, in string) {
+func (ts *testServer) backendPutString(bucket, key string, meta map[string]string, in string) {
 	ts.Helper()
 	ts.OK(ts.backend.PutObject(bucket, key, meta, strings.NewReader(in), int64(len(in))))
 }
 
-func (ts *testServer) objectAsString(bucket, key string, rnge *gofakes3.ObjectRangeRequest) string {
+func (ts *testServer) backendPutBytes(bucket, key string, meta map[string]string, in []byte) {
+	ts.Helper()
+	ts.OK(ts.backend.PutObject(bucket, key, meta, bytes.NewReader(in), int64(len(in))))
+}
+
+func (ts *testServer) backendGetString(bucket, key string, rnge *gofakes3.ObjectRangeRequest) string {
 	ts.Helper()
 	if rnge == nil {
 		rnge = &gofakes3.ObjectRangeRequest{}

--- a/messages.go
+++ b/messages.go
@@ -252,6 +252,7 @@ type Object struct {
 	Size     int64
 	Contents io.ReadCloser
 	Hash     []byte
+	Range    ObjectRange
 }
 
 // UploadID uses a string as the underlying type, but the string should only

--- a/messages.go
+++ b/messages.go
@@ -252,7 +252,7 @@ type Object struct {
 	Size     int64
 	Contents io.ReadCloser
 	Hash     []byte
-	Range    ObjectRange
+	Range    *ObjectRange
 }
 
 // UploadID uses a string as the underlying type, but the string should only

--- a/range.go
+++ b/range.go
@@ -1,0 +1,121 @@
+package gofakes3
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type ObjectRange struct {
+	Start, Length int64
+}
+
+var zeroRange ObjectRange
+
+func (o ObjectRange) IsZero() bool { return o == zeroRange }
+
+func (o ObjectRange) writeHeader(sz int64, w http.ResponseWriter) {
+	if !o.IsZero() {
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", o.Start, o.Start+o.Length-1, sz))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", o.Length))
+	} else {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", sz))
+	}
+}
+
+type ObjectRangeRequest struct {
+	Start, End int64
+	FromEnd    bool
+}
+
+var zeroRangeRequest ObjectRangeRequest
+
+func (o ObjectRangeRequest) IsZero() bool { return o == zeroRangeRequest }
+
+func (o ObjectRangeRequest) Range(size int64) ObjectRange {
+	var start, length int64
+
+	if !o.FromEnd {
+		// If no end is specified, range extends to end of the file.
+		start = o.Start
+		end := o.End
+		if end >= size {
+			end = size - 1
+		}
+		if o.End == 0 {
+			length = size - o.Start
+		} else {
+			length = end - o.Start + 1
+		}
+
+	} else {
+		// If no start is specified, end specifies the range start relative
+		// to the end of the file.
+		end := o.End
+		if end > size {
+			end = size
+		}
+		start = size - end
+		length = size - start
+
+	}
+
+	return ObjectRange{Start: start, Length: length}
+}
+
+// parseHeader takes a bit of a shortcut and fails if you pass multiple ranges.
+// Need to verify whether S3 supports this as it will lead to a backward
+// compatibilty break in the Backend struct. May never be a problem in practice.
+func (o *ObjectRangeRequest) parseHeader(s string) error {
+	if s == "" {
+		return nil
+	}
+
+	const b = "bytes="
+	if !strings.HasPrefix(s, b) {
+		return ErrInvalidRange
+	}
+
+	ranges := strings.Split(s[len(b):], ",")
+	if len(ranges) > 1 {
+		return ErrorMessage(ErrNotImplemented, "multiple ranges not supported")
+	}
+
+	rnge := strings.TrimSpace(ranges[0])
+	if len(rnge) == 0 {
+		return nil
+	}
+
+	i := strings.Index(rnge, "-")
+	if i < 0 {
+		return ErrInvalidRange
+	}
+
+	start, end := strings.TrimSpace(rnge[:i]), strings.TrimSpace(rnge[i+1:])
+	if start == "" {
+		o.FromEnd = true
+
+		i, err := strconv.ParseInt(end, 10, 64)
+		if err != nil {
+			return ErrInvalidRange
+		}
+		o.End = i
+
+	} else {
+		i, err := strconv.ParseInt(start, 10, 64)
+		if err != nil || i < 0 {
+			return ErrInvalidRange
+		}
+		o.Start = i
+		if end != "" {
+			i, err := strconv.ParseInt(end, 10, 64)
+			if err != nil || o.Start > i {
+				return ErrInvalidRange
+			}
+			o.End = i
+		}
+	}
+
+	return nil
+}

--- a/range.go
+++ b/range.go
@@ -64,9 +64,10 @@ func (o ObjectRangeRequest) Range(size int64) ObjectRange {
 	return ObjectRange{Start: start, Length: length}
 }
 
-// parseHeader takes a bit of a shortcut and fails if you pass multiple ranges.
-// Need to verify whether S3 supports this as it will lead to a backward
-// compatibilty break in the Backend struct. May never be a problem in practice.
+// parseHeader parses a single byte range from the Range header.
+//
+// Amazon S3 doesn't support retrieving multiple ranges of data per GET request:
+// https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
 func (o *ObjectRangeRequest) parseHeader(s string) error {
 	if s == "" {
 		return nil

--- a/routing_test.go
+++ b/routing_test.go
@@ -7,8 +7,8 @@ import (
 func TestRoutingSlashes(t *testing.T) {
 	ts := newTestServer(t, withoutInitialBuckets())
 	defer ts.Close()
-	ts.createBucket("test")
-	ts.putString("test", "obj", nil, "yep")
+	ts.backendCreateBucket("test")
+	ts.backendPutString("test", "obj", nil, "yep")
 
 	client := httpClient()
 


### PR DESCRIPTION
The AWS CLI will spill to using range requests and download multiple parts in parallel as the object size gets bigger. This PR adds support for the Range header when downloading an object.

This PR will conflict with #21, it would probably make sense for us to get this one up to scratch first, then I can fix up those afero backends to support the change to the backend interface.