### PR TITLE
Breaking Backend interface into smaller pieces

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -227,7 +227,13 @@ type Backend interface {
 	// The size can be used if the backend needs to read the whole reader; use
 	// gofakes3.ReadAll() for this job rather than ioutil.ReadAll().
 	PutObject(bucketName, key string, meta map[string]string, input io.Reader, size int64) (PutObjectResult, error)
+}
 
+// DeleteMultiBackend may be optionally implemented by a Backend in order to support
+// multi-delete operations directly. If this is not implemented, GoFakeS3 will
+// attempt to emulate it, which may be suboptimal or insufficiently well
+// controlled for your needs.
+type DeleteMultiBackend interface {
 	DeleteMulti(bucketName string, objects ...string) (MultiDeleteResult, error)
 }
 

--- a/backend/s3afero/backend_test.go
+++ b/backend/s3afero/backend_test.go
@@ -266,7 +266,7 @@ func TestPutDeleteMulti(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			deleteResult, err := backend.DeleteMulti("test", "foo/bar", "foo/baz")
+			deleteResult, err := backend.(gofakes3.DeleteMultiBackend).DeleteMulti("test", "foo/bar", "foo/baz")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -41,6 +41,7 @@ type MultiBucketBackend struct {
 }
 
 var _ gofakes3.Backend = &MultiBucketBackend{}
+var _ gofakes3.DeleteMultiBackend = &MultiBucketBackend{}
 
 func MultiBucket(fs afero.Fs, opts ...MultiOption) (*MultiBucketBackend, error) {
 	if err := ensureNoOsFs("fs", fs); err != nil {

--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -41,6 +41,7 @@ type MultiBucketBackend struct {
 }
 
 var _ gofakes3.Backend = &MultiBucketBackend{}
+var _ gofakes3.BucketManagerBackend = &MultiBucketBackend{}
 var _ gofakes3.DeleteMultiBackend = &MultiBucketBackend{}
 
 func MultiBucket(fs afero.Fs, opts ...MultiOption) (*MultiBucketBackend, error) {

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -37,6 +37,7 @@ type SingleBucketBackend struct {
 }
 
 var _ gofakes3.Backend = &SingleBucketBackend{}
+var _ gofakes3.DeleteMultiBackend = &SingleBucketBackend{}
 
 func SingleBucket(name string, fs afero.Fs, metaFs afero.Fs, opts ...SingleOption) (*SingleBucketBackend, error) {
 	if err := ensureNoOsFs("fs", fs); err != nil {

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -18,8 +18,9 @@ import (
 	"github.com/spf13/afero"
 )
 
-// SingleBucketBackend is a gofakes3.Backend that allows you to treat an existing
-// filesystem as an S3 bucket directly. It does not support multiple buckets.
+// SingleBucketBackend is a gofakes3.Backend that allows you to treat an
+// existing filesystem as an S3 bucket directly. It does not implement
+// gofakes3.BucketManagerBackend and does not support multiple buckets.
 //
 // A second afero.Fs, metaFs, may be passed; if this is nil,
 // afero.NewMemMapFs() is used and the metadata will not persist between
@@ -403,18 +404,6 @@ func (db *SingleBucketBackend) deleteObjectLocked(bucketName, objectName string)
 	}
 
 	return nil
-}
-
-// CreateBucket cannot be implemented by this backend. See MultiBucketBackend if you
-// need a backend that supports it.
-func (db *SingleBucketBackend) CreateBucket(name string) error {
-	return gofakes3.ErrNotImplemented
-}
-
-// DeleteBucket cannot be implemented by this backend. See MultiBucketBackend if you
-// need a backend that supports it.
-func (db *SingleBucketBackend) DeleteBucket(name string) error {
-	return gofakes3.ErrNotImplemented
 }
 
 func (db *SingleBucketBackend) BucketExists(name string) (exists bool, err error) {

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -25,6 +25,7 @@ type Backend struct {
 }
 
 var _ gofakes3.Backend = &Backend{}
+var _ gofakes3.DeleteMultiBackend = &Backend{}
 
 type Option func(b *Backend)
 

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -25,6 +25,7 @@ type Backend struct {
 }
 
 var _ gofakes3.Backend = &Backend{}
+var _ gofakes3.BucketManagerBackend = &Backend{}
 var _ gofakes3.DeleteMultiBackend = &Backend{}
 
 type Option func(b *Backend)

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -25,9 +25,7 @@ type Backend struct {
 	lock             sync.RWMutex
 }
 
-var _ gofakes3.Backend = &Backend{}
-var _ gofakes3.DeleteMultiBackend = &Backend{}
-var _ gofakes3.VersionedBackend = &Backend{}
+var _ gofakes3.CompleteBackend = &Backend{}
 
 type Option func(b *Backend)
 

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -26,6 +26,7 @@ type Backend struct {
 }
 
 var _ gofakes3.Backend = &Backend{}
+var _ gofakes3.DeleteMultiBackend = &Backend{}
 var _ gofakes3.VersionedBackend = &Backend{}
 
 type Option func(b *Backend)

--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -209,7 +209,11 @@ func run() error {
 	}
 
 	if values.initialBucket != "" {
-		if err := backend.CreateBucket(values.initialBucket); err != nil && !gofakes3.IsAlreadyExists(err) {
+		bucketmgr, ok := backend.(gofakes3.BucketManagerBackend)
+		if !ok {
+			return fmt.Errorf("gofakes3: configured backend type %T does not support bucket creation", backend)
+		}
+		if err := bucketmgr.CreateBucket(values.initialBucket); err != nil && !gofakes3.IsAlreadyExists(err) {
 			return fmt.Errorf("gofakes3: could not create initial bucket %q: %v", values.initialBucket, err)
 		}
 		log.Println("created -initialbucket", values.initialBucket)

--- a/option.go
+++ b/option.go
@@ -80,3 +80,14 @@ func WithoutVersioning() Option {
 func WithUnimplementedPageError() Option {
 	return func(g *GoFakeS3) { g.failOnUnimplementedPage = true }
 }
+
+// WithoutSimulatedDeleteMulti prevents DeleteMultiBackend from being simulated
+// if it is not implemented by the chosen backend. DeleteMulti will return
+// ErrNotImplemented instead.
+func WithoutSimulatedDeleteMulti() Option {
+	return func(g *GoFakeS3) {
+		if _, ok := g.deleteMultiBackend.(*deleteMultiSimulator); ok {
+			g.deleteMultiBackend = &deleteMultiDisabled{}
+		}
+	}
+}


### PR DESCRIPTION
The Backend interface, in aggregate, is large and getting larger. I've started establishing a pattern with the versioning support for having interface subsets that a backend implementer can optionally support. The use case for this is one I found myself running into regularly when working with Afero, and also with a FUSE-based project: when there's a huge API surface, but you only need to support a reasonable subset of it for your use-case, it can be cumbersome and inconvenient to do so without some help from the API itself.

As I feel one of the key value propositions gofakes3 offers is in testing S3 integrations in the context of your own project's infrastructure without having to resort to Mock Soup, I think this is something we should be working towards making convenient, so here's an attempt at doing some of that! The idea here is that if you needed to provide your own backend, there would be areas of the S3 integration surface that were relevant to your project, and areas that were not, so you shouldn't be forced to implement the latter.

The two things I've done here in service of that are to break DeleteMulti into a separate interface (it is now polyfilled if your backend doesn't support it directly) and to move CreateBucket and DeleteBucket into a separate interface too (this positively affects the Afero single-bucket backend, which has now had its ErrNotImplemented methods removed).

The upshot is that the core `Backend` interface is now only 7 methods, and ideally it would stay hovering around that, which is pretty reasonable from an implementer's point of view. Inside of that, there are some cases where you can cut corners as well (for example, we don't properly support pagination in ListBuckets yet, which turns out to be absolutely fine in practice), so I'll spend some time flushing those out and documenting them in the interface. It's not exactly _trivial_ to implement a Backend, but it shouldn't be mystifyingly difficult to go from "zero" to the guts of a functioning one in a short amount of time either.

~**NOTE** - this PR is based on https://github.com/johannesboyne/gofakes3/pull/28 and depends on that merge, so it should stay WIP until that one has been given a thorough dissection!~ Also need a test on the DeleteMulti polyfill process.

TODO:

- [ ] Test DeleteMulti polyfill process