### PR TITLE
Pagination for list bucket

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -94,21 +94,12 @@ type ListBucketVersionsPage struct {
 }
 
 type ListBucketPage struct {
-	// Specifies the key in the bucket that represents the first item on
-	// the first page in the set.
+	// Specifies the key in the bucket that represents the last item in
+	// the previous page. The first key in the returned page will be the
+	// next lexicographically (UTF-8 binary) sorted key after Marker.
 	// If HasMarker is true, this must be non-empty.
 	Marker    string
 	HasMarker bool
-
-	// Marker indicates the key directly before the first item on the first
-	// page in the set, rather than the first item itself.
-	//
-	// Backend implementers only have to handle this one corner case and get
-	// support for both of S3's bucket listing endpoints in exchange. Seems
-	// like a fair swap, but it'd still be great to get rid of it somehow if we
-	// can. If a Backend fails to implement this, the results will include the
-	// start-after key rather than skipping it.
-	StartAfterMarker bool
 
 	// Sets the maximum number of keys returned in the response body. The
 	// response might contain fewer keys, but will never contain more. If

--- a/backend.go
+++ b/backend.go
@@ -96,9 +96,19 @@ type ListBucketVersionsPage struct {
 type ListBucketPage struct {
 	// Specifies the key in the bucket that represents the first item on
 	// the first page in the set.
-	// If HasStartAfter is true, this must be non-empty.
-	StartAfter    string
-	HasStartAfter bool
+	// If HasMarker is true, this must be non-empty.
+	Marker    string
+	HasMarker bool
+
+	// Marker indicates the key directly before the first item on the first
+	// page in the set, rather than the first item itself.
+	//
+	// Backend implementers only have to handle this one corner case and get
+	// support for both of S3's bucket listing endpoints in exchange. Seems
+	// like a fair swap, but it'd still be great to get rid of it somehow if we
+	// can. If a Backend fails to implement this, the results will include the
+	// start-after key rather than skipping it.
+	StartAfterMarker bool
 
 	// Sets the maximum number of keys returned in the response body. The
 	// response might contain fewer keys, but will never contain more. If

--- a/backend.go
+++ b/backend.go
@@ -89,7 +89,7 @@ type ListBucketVersionsPage struct {
 	// <isTruncated>true</isTruncated>. To return the additional keys, see
 	// key-marker and version-id-marker.
 	//
-	// MaxKeys MUST be > 0.
+	// MaxKeys MUST be > 0, otherwise it is ignored.
 	MaxKeys int64
 }
 
@@ -108,7 +108,7 @@ type ListBucketPage struct {
 	// <isTruncated>true</isTruncated>. To return the additional keys, see
 	// key-marker and version-id-marker.
 	//
-	// MaxKeys MUST be > 0.
+	// MaxKeys MUST be > 0, otherwise it is ignored.
 	MaxKeys int64
 }
 

--- a/backend/s3afero/backend_test.go
+++ b/backend/s3afero/backend_test.go
@@ -142,7 +142,9 @@ func TestPutListRoot(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result, err := backend.ListBucket("test", &gofakes3.Prefix{HasPrefix: true, HasDelimiter: true, Delimiter: "/"})
+			result, err := backend.ListBucket("test",
+				&gofakes3.Prefix{HasPrefix: true, HasDelimiter: true, Delimiter: "/"},
+				gofakes3.ListBucketPage{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -187,7 +189,9 @@ func TestPutListDir(t *testing.T) {
 			}
 
 			{
-				result, err := backend.ListBucket("test", &gofakes3.Prefix{Prefix: "foo/", HasPrefix: true, HasDelimiter: true, Delimiter: "/"})
+				result, err := backend.ListBucket("test",
+					&gofakes3.Prefix{Prefix: "foo/", HasPrefix: true, HasDelimiter: true, Delimiter: "/"},
+					gofakes3.ListBucketPage{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -197,7 +201,9 @@ func TestPutListDir(t *testing.T) {
 			}
 
 			{
-				result, err := backend.ListBucket("test", &gofakes3.Prefix{Prefix: "foo/bar", HasPrefix: true, HasDelimiter: true, Delimiter: "/"})
+				result, err := backend.ListBucket("test",
+					&gofakes3.Prefix{Prefix: "foo/bar", HasPrefix: true, HasDelimiter: true, Delimiter: "/"},
+					gofakes3.ListBucketPage{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -227,7 +233,9 @@ func TestPutDelete(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result, err := backend.ListBucket("test", &gofakes3.Prefix{HasPrefix: true, HasDelimiter: true, Delimiter: "/"})
+			result, err := backend.ListBucket("test",
+				&gofakes3.Prefix{HasPrefix: true, HasDelimiter: true, Delimiter: "/"},
+				gofakes3.ListBucketPage{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -266,7 +274,9 @@ func TestPutDeleteMulti(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			bucketContents, err := backend.ListBucket("test", &gofakes3.Prefix{HasPrefix: true, HasDelimiter: true, Delimiter: "/"})
+			bucketContents, err := backend.ListBucket("test",
+				&gofakes3.Prefix{HasPrefix: true, HasDelimiter: true, Delimiter: "/"},
+				gofakes3.ListBucketPage{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -326,8 +326,8 @@ func (db *MultiBucketBackend) GetObject(bucketName, objectName string, rangeRequ
 	}
 
 	defer func() {
-		// If an error occurs, the caller won't have access to Object.Body in order to close it:
-		if rerr != nil {
+		// If an error occurs, the caller may not have access to Object.Body in order to close it:
+		if obj == nil && rerr != nil {
 			f.Close()
 		}
 	}()

--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -95,13 +95,15 @@ func (db *MultiBucketBackend) ListBuckets() ([]gofakes3.BucketInfo, error) {
 	return buckets, nil
 }
 
-func (db *MultiBucketBackend) ListBucket(bucket string, prefix *gofakes3.Prefix) (*gofakes3.ListBucketResult, error) {
+func (db *MultiBucketBackend) ListBucket(bucket string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
 	if prefix == nil {
 		prefix = emptyPrefix
 	}
-
 	if err := gofakes3.ValidateBucketName(bucket); err != nil {
 		return nil, gofakes3.BucketNotFound(bucket)
+	}
+	if !page.IsEmpty() {
+		return nil, gofakes3.ErrInternalPageNotImplemented
 	}
 
 	db.lock.Lock()
@@ -115,7 +117,7 @@ func (db *MultiBucketBackend) ListBucket(bucket string, prefix *gofakes3.Prefix)
 	}
 }
 
-func (db *MultiBucketBackend) getBucketWithFilePrefixLocked(bucket string, prefixPath, prefixPart string) (*gofakes3.ListBucketResult, error) {
+func (db *MultiBucketBackend) getBucketWithFilePrefixLocked(bucket string, prefixPath, prefixPart string) (*gofakes3.ObjectList, error) {
 	bucketPath := path.Join(bucket, prefixPath)
 
 	dirEntries, err := afero.ReadDir(db.bucketFs, filepath.FromSlash(bucketPath))
@@ -125,7 +127,7 @@ func (db *MultiBucketBackend) getBucketWithFilePrefixLocked(bucket string, prefi
 		return nil, err
 	}
 
-	response := gofakes3.NewListBucketResult(bucket)
+	response := gofakes3.NewObjectList()
 
 	for _, entry := range dirEntries {
 		object := entry.Name()
@@ -161,7 +163,7 @@ func (db *MultiBucketBackend) getBucketWithFilePrefixLocked(bucket string, prefi
 	return response, nil
 }
 
-func (db *MultiBucketBackend) getBucketWithArbitraryPrefixLocked(bucket string, prefix *gofakes3.Prefix) (*gofakes3.ListBucketResult, error) {
+func (db *MultiBucketBackend) getBucketWithArbitraryPrefixLocked(bucket string, prefix *gofakes3.Prefix) (*gofakes3.ObjectList, error) {
 	stat, err := db.bucketFs.Stat(filepath.FromSlash(bucket))
 	if os.IsNotExist(err) {
 		return nil, gofakes3.BucketNotFound(bucket)
@@ -171,7 +173,7 @@ func (db *MultiBucketBackend) getBucketWithArbitraryPrefixLocked(bucket string, 
 		return nil, fmt.Errorf("gofakes3: expected %q to be a bucket path", bucket)
 	}
 
-	response := gofakes3.NewListBucketResult(bucket)
+	response := gofakes3.NewObjectList()
 
 	if err := afero.Walk(db.bucketFs, filepath.FromSlash(bucket), func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {

--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -340,7 +340,11 @@ func (db *MultiBucketBackend) GetObject(bucketName, objectName string, rangeRequ
 	size, mtime := stat.Size(), stat.ModTime()
 
 	var rdr io.ReadCloser = f
-	rnge := rangeRequest.Range(size)
+	rnge, err := rangeRequest.Range(size)
+	if err != nil {
+		return nil, err
+	}
+
 	if rnge != nil {
 		if _, err := f.Seek(rnge.Start, io.SeekStart); err != nil {
 			return nil, err

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -91,12 +91,15 @@ func (db *SingleBucketBackend) ListBuckets() ([]gofakes3.BucketInfo, error) {
 	}, nil
 }
 
-func (db *SingleBucketBackend) ListBucket(bucket string, prefix *gofakes3.Prefix) (*gofakes3.ListBucketResult, error) {
+func (db *SingleBucketBackend) ListBucket(bucket string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
 	if bucket != db.name {
 		return nil, gofakes3.BucketNotFound(bucket)
 	}
 	if prefix == nil {
 		prefix = emptyPrefix
+	}
+	if !page.IsEmpty() {
+		return nil, gofakes3.ErrInternalPageNotImplemented
 	}
 
 	db.lock.Lock()
@@ -110,13 +113,13 @@ func (db *SingleBucketBackend) ListBucket(bucket string, prefix *gofakes3.Prefix
 	}
 }
 
-func (db *SingleBucketBackend) getBucketWithFilePrefixLocked(bucket string, prefixPath, prefixPart string) (*gofakes3.ListBucketResult, error) {
+func (db *SingleBucketBackend) getBucketWithFilePrefixLocked(bucket string, prefixPath, prefixPart string) (*gofakes3.ObjectList, error) {
 	dirEntries, err := afero.ReadDir(db.fs, filepath.FromSlash(prefixPath))
 	if err != nil {
 		return nil, err
 	}
 
-	response := gofakes3.NewListBucketResult(bucket)
+	response := gofakes3.NewObjectList()
 
 	for _, entry := range dirEntries {
 		object := entry.Name()
@@ -152,8 +155,8 @@ func (db *SingleBucketBackend) getBucketWithFilePrefixLocked(bucket string, pref
 	return response, nil
 }
 
-func (db *SingleBucketBackend) getBucketWithArbitraryPrefixLocked(bucket string, prefix *gofakes3.Prefix) (*gofakes3.ListBucketResult, error) {
-	response := gofakes3.NewListBucketResult(bucket)
+func (db *SingleBucketBackend) getBucketWithArbitraryPrefixLocked(bucket string, prefix *gofakes3.Prefix) (*gofakes3.ObjectList, error) {
+	response := gofakes3.NewObjectList()
 
 	if err := afero.Walk(db.fs, filepath.FromSlash(bucket), func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -258,7 +258,11 @@ func (db *SingleBucketBackend) GetObject(bucketName, objectName string, rangeReq
 	size, mtime := stat.Size(), stat.ModTime()
 
 	var rdr io.ReadCloser = f
-	rnge := rangeRequest.Range(size)
+	rnge, err := rangeRequest.Range(size)
+	if err != nil {
+		return nil, err
+	}
+
 	if rnge != nil {
 		if _, err := f.Seek(rnge.Start, io.SeekStart); err != nil {
 			return nil, err

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -285,7 +285,7 @@ func (db *Backend) GetObject(bucketName, objectName string, rangeRequest *gofake
 
 	// FIXME: objectName here is a bit of a hack; this can be cleaned up when we have a
 	// database migration script.
-	return t.Object(objectName, rangeRequest), nil
+	return t.Object(objectName, rangeRequest)
 }
 
 func (db *Backend) PutObject(

--- a/backend/s3bolt/schema.go
+++ b/backend/s3bolt/schema.go
@@ -29,10 +29,14 @@ type boltObject struct {
 	Hash         []byte
 }
 
-func (b *boltObject) Object(objectName string, rangeRequest *gofakes3.ObjectRangeRequest) *gofakes3.Object {
+func (b *boltObject) Object(objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
 	data := b.Contents
 
-	rnge := rangeRequest.Range(b.Size)
+	rnge, err := rangeRequest.Range(b.Size)
+	if err != nil {
+		return nil, err
+	}
+
 	if rnge != nil {
 		data = data[rnge.Start : rnge.Start+rnge.Length]
 	}
@@ -44,7 +48,7 @@ func (b *boltObject) Object(objectName string, rangeRequest *gofakes3.ObjectRang
 		Contents: s3io.ReaderWithDummyCloser{bytes.NewReader(data)},
 		Range:    rnge,
 		Hash:     b.Hash,
-	}
+	}, nil
 }
 
 func bucketMetaKey(name string) []byte {

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -181,7 +181,7 @@ func (db *Backend) HeadObject(bucketName, objectName string) (*gofakes3.Object, 
 		return nil, gofakes3.KeyNotFound(objectName)
 	}
 
-	return obj.data.toObject(nil, false), nil
+	return obj.data.toObject(nil, false)
 }
 
 func (db *Backend) GetObject(bucketName, objectName string, rangeRequest *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
@@ -204,7 +204,11 @@ func (db *Backend) GetObject(bucketName, objectName string, rangeRequest *gofake
 		return nil, gofakes3.KeyNotFound(objectName)
 	}
 
-	result := obj.data.toObject(rangeRequest, true)
+	result, err := obj.data.toObject(rangeRequest, true)
+	if err != nil {
+		return nil, err
+	}
+
 	if bucket.versioning != gofakes3.VersioningEnabled {
 		result.VersionID = ""
 	}
@@ -344,7 +348,7 @@ func (db *Backend) GetObjectVersion(
 		return nil, err
 	}
 
-	return ver.toObject(rangeRequest, true), nil
+	return ver.toObject(rangeRequest, true)
 }
 
 func (db *Backend) HeadObjectVersion(bucketName, objectName string, versionID gofakes3.VersionID) (*gofakes3.Object, error) {
@@ -361,7 +365,7 @@ func (db *Backend) HeadObjectVersion(bucketName, objectName string, versionID go
 		return nil, err
 	}
 
-	return ver.toObject(nil, false), nil
+	return ver.toObject(nil, false)
 }
 
 func (db *Backend) DeleteObjectVersion(bucketName, objectName string, versionID gofakes3.VersionID) (result gofakes3.ObjectDeleteResult, rerr error) {

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -73,9 +73,12 @@ func (db *Backend) ListBuckets() ([]gofakes3.BucketInfo, error) {
 	return buckets, nil
 }
 
-func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix) (*gofakes3.ListBucketResult, error) {
+func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
 	if prefix == nil {
 		prefix = emptyPrefix
+	}
+	if !page.IsEmpty() {
+		return nil, gofakes3.ErrInternalPageNotImplemented
 	}
 
 	db.lock.RLock()
@@ -86,7 +89,7 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix) (*gofakes3.L
 		return nil, gofakes3.BucketNotFound(name)
 	}
 
-	response := gofakes3.NewListBucketResult(name)
+	response := gofakes3.NewObjectList()
 	iter := storedBucket.objects.Iterator()
 
 	var match gofakes3.PrefixMatch

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -95,9 +95,7 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 
 	if page.Marker != "" {
 		iter.Seek(page.Marker)
-		if page.StartAfterMarker {
-			iter.Next()
-		}
+		iter.Next() // Move to the next item after the Marker
 	}
 
 	var cnt int64 = 0
@@ -122,13 +120,10 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 
 		cnt++
 		if cnt >= page.MaxKeys {
+			response.NextMarker = item.data.name
 			response.IsTruncated = iter.Next()
 			break
 		}
-	}
-
-	if response.IsTruncated {
-		response.NextMarker = iter.Value().(*bucketObject).name
 	}
 
 	return response, nil

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -77,9 +77,6 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 	if prefix == nil {
 		prefix = emptyPrefix
 	}
-	if !page.IsEmpty() {
-		return nil, gofakes3.ErrInternalPageNotImplemented
-	}
 
 	db.lock.RLock()
 	defer db.lock.RUnlock()

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -100,6 +100,8 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 
 	var cnt int64 = 0
 
+	var lastMatchedPart string
+
 	for iter.Next() {
 		item := iter.Value().(*bucketObject)
 
@@ -107,7 +109,11 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 			continue
 
 		} else if match.CommonPrefix {
+			if match.MatchedPart == lastMatchedPart {
+				continue // Should not count towards keys
+			}
 			response.AddPrefix(match.MatchedPart)
+			lastMatchedPart = match.MatchedPart
 
 		} else {
 			response.Add(&gofakes3.Content{

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -119,7 +119,7 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 		}
 
 		cnt++
-		if cnt >= page.MaxKeys {
+		if page.MaxKeys > 0 && cnt >= page.MaxKeys {
 			response.NextMarker = item.data.name
 			response.IsTruncated = iter.Next()
 			break
@@ -470,7 +470,7 @@ func (db *Backend) ListBucketVersions(
 			}
 
 			cnt++
-			if cnt >= page.MaxKeys {
+			if page.MaxKeys > 0 && cnt >= page.MaxKeys {
 				truncated = versions.Next()
 				goto done
 			}

--- a/backend/s3mem/bucket.go
+++ b/backend/s3mem/bucket.go
@@ -122,7 +122,7 @@ type bucketData struct {
 	metadata     map[string]string
 }
 
-func (bi *bucketData) toObject(rangeRequest *gofakes3.ObjectRangeRequest, withBody bool) *gofakes3.Object {
+func (bi *bucketData) toObject(rangeRequest *gofakes3.ObjectRangeRequest, withBody bool) (obj *gofakes3.Object, err error) {
 	sz := int64(len(bi.body))
 	data := bi.body
 
@@ -131,7 +131,11 @@ func (bi *bucketData) toObject(rangeRequest *gofakes3.ObjectRangeRequest, withBo
 
 	if withBody {
 		// In case of a range request the correct part of the slice is extracted:
-		rnge = rangeRequest.Range(sz)
+		rnge, err = rangeRequest.Range(sz)
+		if err != nil {
+			return nil, err
+		}
+
 		if rnge != nil {
 			data = data[rnge.Start : rnge.Start+rnge.Length]
 		}
@@ -153,7 +157,7 @@ func (bi *bucketData) toObject(rangeRequest *gofakes3.ObjectRangeRequest, withBo
 		IsDeleteMarker: bi.deleteMarker,
 		VersionID:      bi.versionID,
 		Contents:       contents,
-	}
+	}, nil
 }
 
 func (b *bucket) setVersioning(enabled bool) {

--- a/constants.go
+++ b/constants.go
@@ -28,10 +28,14 @@ const (
 
 	DefaultSkewLimit = 15 * time.Minute
 
-	MaxUploadsLimit             = 1000
-	DefaultMaxUploads           = 1000
-	MaxUploadPartsLimit         = 1000
-	DefaultMaxUploadParts       = 1000
+	MaxUploadsLimit       = 1000
+	DefaultMaxUploads     = 1000
+	MaxUploadPartsLimit   = 1000
+	DefaultMaxUploadParts = 1000
+
+	MaxBucketKeys        = 1000
+	DefaultMaxBucketKeys = 1000
+
 	MaxBucketVersionKeys        = 1000
 	DefaultMaxBucketVersionKeys = 1000
 

--- a/error.go
+++ b/error.go
@@ -49,6 +49,7 @@ const (
 	ErrInvalidDigest ErrorCode = "InvalidDigest"
 
 	ErrInvalidRange         ErrorCode = "InvalidRange"
+	ErrInvalidToken         ErrorCode = "InvalidToken"
 	ErrKeyTooLong           ErrorCode = "KeyTooLongError" // This is not a typo: Error is part of the string, but redundant in the constant name
 	ErrMalformedPOSTRequest ErrorCode = "MalformedPOSTRequest"
 
@@ -87,6 +88,12 @@ const (
 	ErrNotImplemented       ErrorCode = "NotImplemented"
 
 	ErrInternal ErrorCode = "InternalError"
+)
+
+// INTERNAL errors! These are not part of the S3 interface, they are codes
+// we have declared ourselves. Should all map to a 500 status code:
+const (
+	ErrInternalPageNotImplemented InternalErrorCode = "PaginationNotImplemented"
 )
 
 // errorResponse should be implemented by any type that needs to be handled by
@@ -194,6 +201,13 @@ type ErrorCode string
 func (e ErrorCode) ErrorCode() ErrorCode { return e }
 func (e ErrorCode) Error() string        { return string(e) }
 
+// InternalErrorCode represents an GoFakeS3 error code. It maps to ErrInternal
+// when constructing a response.
+type InternalErrorCode string
+
+func (e InternalErrorCode) ErrorCode() ErrorCode { return ErrInternal }
+func (e InternalErrorCode) Error() string        { return string(ErrInternal) }
+
 // Message tries to return the same string as S3 would return for the error
 // response, when it is known, or nothing when it is not. If you see the status
 // text for a code we don't have listed in here in the wild, please let us
@@ -227,6 +241,7 @@ func (e ErrorCode) Status() int {
 		ErrInvalidDigest,
 		ErrInvalidPart,
 		ErrInvalidPartOrder,
+		ErrInvalidToken,
 		ErrInvalidURI,
 		ErrKeyTooLong,
 		ErrMetadataTooLarge,

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/johannesboyne/gofakes3
 require (
 	github.com/aws/aws-sdk-go v1.17.4
 	github.com/boltdb/bolt v1.3.1
+	github.com/davecgh/go-spew v1.1.0
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46
 	github.com/shabbyrobe/gocovmerge v0.0.0-20180507124511-f6ea450bfb63
 	github.com/spf13/afero v1.2.1

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -184,6 +184,7 @@ func (g *GoFakeS3) listBucket(bucketName string, w http.ResponseWriter, r *http.
 	g.log.Print(LogInfo, "prefix    :", prefix)
 
 	objects, err := g.storage.ListBucket(bucketName, &prefix, page)
+
 	if err != nil {
 		if err == ErrInternalPageNotImplemented && !g.failOnUnimplementedPage {
 			// We have observed (though not yet confirmed) that simple clients

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -182,6 +182,7 @@ func (g *GoFakeS3) listBucket(bucketName string, w http.ResponseWriter, r *http.
 
 	g.log.Print(LogInfo, "bucketname:", bucketName)
 	g.log.Print(LogInfo, "prefix    :", prefix)
+	g.log.Print(LogInfo, "page      :", fmt.Sprintf("%+v", page))
 
 	objects, err := g.storage.ListBucket(bucketName, &prefix, page)
 

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -2,6 +2,7 @@ package gofakes3
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
@@ -25,14 +26,15 @@ type GoFakeS3 struct {
 	storage   Backend
 	versioned VersionedBackend
 
-	timeSource        TimeSource
-	timeSkew          time.Duration
-	metadataSizeLimit int
-	integrityCheck    bool
-	hostBucket        bool
-	uploader          *uploader
-	requestID         uint64
-	log               Logger
+	timeSource              TimeSource
+	timeSkew                time.Duration
+	metadataSizeLimit       int
+	integrityCheck          bool
+	failOnUnimplementedPage bool
+	hostBucket              bool
+	uploader                *uploader
+	requestID               uint64
+	log                     Logger
 }
 
 // New creates a new GoFakeS3 using the supplied Backend. Backends are pluggable.
@@ -154,20 +156,106 @@ func (g *GoFakeS3) listBuckets(w http.ResponseWriter, r *http.Request) error {
 	return g.xmlEncoder(w).Encode(s)
 }
 
+// S3 has two versions of this API, both of which are close to identical. We manage that
+// jank in here so the Backend doesn't have to with the following tricks:
+//
+// - Hiding the NextMarker inside the ContinuationToken for V2 calls
+// - Masking the Owner in the response for V2 calls
+//
+// The wrapping response objects are slightly different too, but the list of
+// objects is pretty much the same.
+//
+// - https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+// - https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
+//
 func (g *GoFakeS3) listBucket(bucketName string, w http.ResponseWriter, r *http.Request) error {
 	g.log.Print(LogInfo, "LIST BUCKET")
 
-	prefix := prefixFromQuery(r.URL.Query())
-
-	g.log.Print(LogInfo, "bucketname:", bucketName)
-	g.log.Print(LogInfo, "prefix    :", prefix)
-
-	bucket, err := g.storage.ListBucket(bucketName, &prefix)
+	q := r.URL.Query()
+	prefix := prefixFromQuery(q)
+	page, err := listBucketPageFromQuery(q)
 	if err != nil {
 		return err
 	}
 
-	return g.xmlEncoder(w).Encode(bucket)
+	isVersion2 := q.Get("list-type") == "2"
+
+	g.log.Print(LogInfo, "bucketname:", bucketName)
+	g.log.Print(LogInfo, "prefix    :", prefix)
+
+	objects, err := g.storage.ListBucket(bucketName, &prefix, page)
+	if err != nil {
+		if err == ErrInternalPageNotImplemented && !g.failOnUnimplementedPage {
+			// We have observed (though not yet confirmed) that simple clients
+			// tend to work fine if you simply ignore pagination, so the
+			// default if this is not implemented is to retry without it. If
+			// you care about this performance impact for some weird reason,
+			// you'll need to handle it yourself.
+			objects, err = g.storage.ListBucket(bucketName, &prefix, ListBucketPage{})
+			if err != nil {
+				return err
+			}
+
+		} else if err == ErrInternalPageNotImplemented && g.failOnUnimplementedPage {
+			return ErrNotImplemented
+		} else {
+			return err
+		}
+	}
+
+	base := ListBucketResultBase{
+		Xmlns:          "http://s3.amazonaws.com/doc/2006-03-01/",
+		Name:           bucketName,
+		CommonPrefixes: objects.CommonPrefixes,
+		Contents:       objects.Contents,
+		IsTruncated:    objects.IsTruncated,
+		Delimiter:      prefix.Delimiter,
+		Prefix:         prefix.Prefix,
+		MaxKeys:        page.MaxKeys,
+	}
+
+	if !isVersion2 {
+		var result = &ListBucketResult{
+			ListBucketResultBase: base,
+			Marker:               page.StartAfter,
+			NextMarker:           objects.NextMarker,
+		}
+		return g.xmlEncoder(w).Encode(result)
+
+	} else {
+		var result = &ListBucketResultV2{
+			ListBucketResultBase: base,
+			KeyCount:             int64(len(objects.CommonPrefixes) + len(objects.Contents)),
+			StartAfter:           page.StartAfter,
+			ContinuationToken:    q.Get("continuation-token"),
+		}
+		if objects.NextMarker != "" {
+			// We are just cheating with these continuation tokens; they're just the NextMarker
+			// from v1 in disguise! That may change at any time and should not be relied upon
+			// though.
+			result.NextContinuationToken = base64.URLEncoding.EncodeToString([]byte(objects.NextMarker))
+		}
+
+		// On the topic of "fetch-owner", the AWS docs say, in typically vague style:
+		// "If you want the owner information in the response, you can specify
+		// this parameter with the value set to true."
+		//
+		// What does the bare word 'true' mean when we're talking about a query
+		// string parameter, which can only be a string? Does it mean the word
+		// 'true'? Does it mean 'any truthy string'? Does it mean only the key
+		// needs to be present (i.e. '?fetch-owner'), which we are assuming
+		// for now? This is why you need proper technical writers.
+		//
+		// Probably need to hit up the s3assumer at some point, but until then, here's
+		// another FIXME!
+		if _, ok := q["fetch-owner"]; !ok {
+			for _, v := range result.Contents {
+				v.Owner = nil
+			}
+		}
+
+		return g.xmlEncoder(w).Encode(result)
+	}
 }
 
 func (g *GoFakeS3) listBucketVersions(bucketName string, w http.ResponseWriter, r *http.Request) error {
@@ -175,8 +263,9 @@ func (g *GoFakeS3) listBucketVersions(bucketName string, w http.ResponseWriter, 
 		return ErrNotImplemented
 	}
 
-	prefix := prefixFromQuery(r.URL.Query())
-	page, err := listBucketVersionsPageFromQuery(r.URL.Query())
+	q := r.URL.Query()
+	prefix := prefixFromQuery(q)
+	page, err := listBucketVersionsPageFromQuery(q)
 	if err != nil {
 		return err
 	}
@@ -816,6 +905,39 @@ func metadataHeaders(headers map[string][]string, at time.Time, sizeLimit int) (
 	}
 
 	return meta, nil
+}
+
+func listBucketPageFromQuery(query url.Values) (page ListBucketPage, rerr error) {
+	maxKeys, err := parseClampedInt(query.Get("max-keys"), DefaultMaxBucketVersionKeys, 0, MaxBucketVersionKeys)
+	if err != nil {
+		return page, err
+	}
+
+	page.MaxKeys = maxKeys
+
+	if _, page.HasStartAfter = query["marker"]; page.HasStartAfter {
+		// List Objects V1 uses marker only:
+		page.StartAfter = query.Get("marker")
+
+	} else if _, page.HasStartAfter = query["continuation-token"]; page.HasStartAfter {
+		// List Objects V2 uses continuation-token preferentially, or
+		// start-after if continuation-token is missing. continuation-token is
+		// an opaque value that looks like this: 1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM=.
+		// This just looks like base64 junk so we just cheat and base64 encode
+		// the next marker and hide it in a continuation-token.
+		tok, err := base64.URLEncoding.DecodeString(query.Get("continuation-token"))
+		if err != nil {
+			// FIXME: log
+			return page, ErrInvalidToken // FIXME: confirm for sure what AWS does here
+		}
+		page.StartAfter = string(tok)
+
+	} else if _, page.HasStartAfter = query["start-after"]; page.HasStartAfter {
+		// List Objects V2 uses start-after if continuation-token is missing:
+		page.StartAfter = query.Get("start-after")
+	}
+
+	return page, nil
 }
 
 func listBucketVersionsPageFromQuery(query url.Values) (page ListBucketVersionsPage, rerr error) {

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -794,7 +794,7 @@ func TestListBucketPagesFallback(t *testing.T) {
 	t.Run("fallback-disabled", func(t *testing.T) {
 		ts := newTestServer(t,
 			withBackend(&backendWithUnimplementedPaging{s3mem.New()}),
-			withFakerOptions(gofakes3.WithUnimplementedPageError(true)),
+			withFakerOptions(gofakes3.WithUnimplementedPageError()),
 		)
 		defer ts.Close()
 		createData(ts, "", 5)

--- a/init_test.go
+++ b/init_test.go
@@ -804,7 +804,7 @@ type backendWithUnimplementedPaging struct {
 	gofakes3.Backend
 }
 
-func (b *backendWithUnimplementedPaging) ListBucket(name string, prefix gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
+func (b *backendWithUnimplementedPaging) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
 	if !page.IsEmpty() {
 		return nil, gofakes3.ErrInternalPageNotImplemented
 	}

--- a/init_test.go
+++ b/init_test.go
@@ -160,6 +160,9 @@ func withVersioning() testServerOption {
 func withFakerOptions(opts ...gofakes3.Option) testServerOption {
 	return func(ts *testServer) { ts.options = opts }
 }
+func withBackend(backend gofakes3.Backend) testServerOption {
+	return func(ts *testServer) { ts.backend = backend }
+}
 
 func newTestServer(t *testing.T, opts ...testServerOption) *testServer {
 	t.Helper()
@@ -795,4 +798,15 @@ func httpClient() *http.Client {
 	return &http.Client{
 		Timeout: 2 * time.Second,
 	}
+}
+
+type backendWithUnimplementedPaging struct {
+	gofakes3.Backend
+}
+
+func (b *backendWithUnimplementedPaging) ListBucket(name string, prefix gofakes3.Prefix, page gofakes3.ListBucketPage) (*gofakes3.ObjectList, error) {
+	if !page.IsEmpty() {
+		return nil, gofakes3.ErrInternalPageNotImplemented
+	}
+	return b.Backend.ListBucket(name, prefix, page)
 }

--- a/messages.go
+++ b/messages.go
@@ -170,6 +170,8 @@ func (er ErrorResult) String() string {
 }
 
 type InitiateMultipartUpload struct {
+	Bucket   string   `xml:"Bucket"`
+	Key      string   `xml:"Key"`
 	UploadID UploadID `xml:"UploadId"`
 }
 

--- a/messages.go
+++ b/messages.go
@@ -210,7 +210,7 @@ type ListBucketResult struct {
 
 	// Indicates where in the bucket listing begins. Marker is included in the
 	// response if it was sent with the request.
-	Marker string `xml:"Marker,omitempty"`
+	Marker string `xml:"Marker"`
 
 	// When the response is truncated (that is, the IsTruncated element value
 	// in the response is true), you can use the key name in this field as a

--- a/messages_test.go
+++ b/messages_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-func TestBucketAddPrefix(t *testing.T) {
-	b := NewListBucketResult("yep")
+func TestObjectListAddPrefix(t *testing.T) {
+	b := NewObjectList()
 	b.AddPrefix("prefix1")
 	if len(b.CommonPrefixes) != 1 {
 		t.Fatal("unexpected prefixes length")

--- a/option.go
+++ b/option.go
@@ -71,6 +71,12 @@ func WithoutVersioning() Option {
 	return func(g *GoFakeS3) { g.versioned = nil }
 }
 
-func WithUnimplementedPageError(enabled bool) Option {
-	return func(g *GoFakeS3) { g.failOnUnimplementedPage = enabled }
+// WithUnimplementedPageError allows you to enable or disable the error that occurs
+// if the Backend does not implement paging.
+//
+// By default, GoFakeS3 will simply retry a request for a page of objects
+// without the page if the Backend does not implement pagination. This can
+// be used to enable an error in that condition instead.
+func WithUnimplementedPageError() Option {
+	return func(g *GoFakeS3) { g.failOnUnimplementedPage = true }
 }

--- a/option.go
+++ b/option.go
@@ -70,3 +70,7 @@ func WithHostBucket(enabled bool) Option {
 func WithoutVersioning() Option {
 	return func(g *GoFakeS3) { g.versioned = nil }
 }
+
+func WithUnimplementedPageError(enabled bool) Option {
+	return func(g *GoFakeS3) { g.failOnUnimplementedPage = enabled }
+}

--- a/prefix.go
+++ b/prefix.go
@@ -72,8 +72,8 @@ func (p Prefix) FilePrefix() (path, remaining string, ok bool) {
 // result to key.
 //
 func (p Prefix) Match(key string, match *PrefixMatch) (ok bool) {
-	if !p.HasPrefix {
-		// If there is no prefix, in the search, the match is the prefix:
+	if !p.HasPrefix && !p.HasDelimiter {
+		// If there is no prefix in the search, the match is the prefix:
 		if match != nil {
 			*match = PrefixMatch{Key: key, MatchedPart: key}
 		}
@@ -147,9 +147,6 @@ func (p Prefix) Match(key string, match *PrefixMatch) (ok bool) {
 }
 
 func (p Prefix) String() string {
-	if !p.HasPrefix {
-		return "<prefix empty>"
-	}
 	if p.HasDelimiter {
 		return fmt.Sprintf("prefix:%q, delim:%q", p.Prefix, p.Delimiter)
 	} else {

--- a/prefix.go
+++ b/prefix.go
@@ -34,6 +34,12 @@ func NewPrefix(prefix, delim *string) (p Prefix) {
 	return p
 }
 
+func NewFolderPrefix(prefix string) (p Prefix) {
+	p.HasPrefix, p.Prefix = true, prefix
+	p.HasDelimiter, p.Delimiter = true, "/"
+	return p
+}
+
 // FilePrefix returns the path portion, then the remaining portion of the
 // Prefix if the Delimiter is "/". If the Delimiter is not set, or not "/",
 // ok will be false.

--- a/range.go
+++ b/range.go
@@ -42,9 +42,6 @@ func (o *ObjectRangeRequest) Range(size int64) (*ObjectRange, error) {
 			// If no end is specified, range extends to end of the file.
 			length = size - start
 		} else {
-			if end >= size {
-				end = size - 1
-			}
 			length = end - start + 1
 		}
 
@@ -52,14 +49,11 @@ func (o *ObjectRangeRequest) Range(size int64) (*ObjectRange, error) {
 		// If no start is specified, end specifies the range start relative
 		// to the end of the file.
 		end := o.End
-		if end > size {
-			end = size
-		}
 		start = size - end
 		length = size - start
 	}
 
-	if start >= size || start+length > size {
+	if start < 0 || length < 0 || start > size || start+length > size {
 		return nil, ErrInvalidRange
 	}
 

--- a/range.go
+++ b/range.go
@@ -27,9 +27,9 @@ type ObjectRangeRequest struct {
 
 const RangeNoEnd = -1
 
-func (o *ObjectRangeRequest) Range(size int64) *ObjectRange {
+func (o *ObjectRangeRequest) Range(size int64) (*ObjectRange, error) {
 	if o == nil {
-		return nil
+		return nil, nil
 	}
 
 	var start, length int64
@@ -40,12 +40,12 @@ func (o *ObjectRangeRequest) Range(size int64) *ObjectRange {
 
 		if o.End == RangeNoEnd {
 			// If no end is specified, range extends to end of the file.
-			length = size - o.Start
+			length = size - start
 		} else {
 			if end >= size {
 				end = size - 1
 			}
-			length = end - o.Start + 1
+			length = end - start + 1
 		}
 
 	} else {
@@ -59,7 +59,11 @@ func (o *ObjectRangeRequest) Range(size int64) *ObjectRange {
 		length = size - start
 	}
 
-	return &ObjectRange{Start: start, Length: length}
+	if start >= size || start+length > size {
+		return nil, ErrInvalidRange
+	}
+
+	return &ObjectRange{Start: start, Length: length}, nil
 }
 
 // parseRangeHeader parses a single byte range from the Range header.

--- a/range_test.go
+++ b/range_test.go
@@ -15,17 +15,18 @@ func TestRangeRequest(t *testing.T) {
 	}{
 		{inst: 0, inend: RangeNoEnd, sz: 5, outst: 0, outln: 5},
 		{inst: 0, inend: 5, sz: 10, outst: 0, outln: 6},
-		{inst: 0, inend: 5, sz: 4, outst: 0, outln: 4},
 		{inst: 0, inend: 0, sz: 4, outst: 0, outln: 1},
 		{inst: 1, inend: 5, sz: 10, outst: 1, outln: 5},
 
 		{rev: true, inend: 10, sz: 10, outst: 0, outln: 10},
 		{rev: true, inend: 5, sz: 10, outst: 5, outln: 5},
-		{rev: true, inend: 20, sz: 10, outst: 0, outln: 10},
 
-		{fail: true, inst: 0, inend: 0, sz: 0, outst: 0, outln: 0},
-		{fail: true, inst: 10, inend: 15, sz: 10, outst: 10, outln: 0},
-		{fail: true, inst: 40, inend: 50, sz: 11, outst: 11, outln: 0},
+		{fail: true, inst: 0, inend: 0, sz: 0},
+		{fail: true, inst: 0, inend: 5, sz: 4},
+		{fail: true, inst: 10, inend: 15, sz: 10},
+		{fail: true, inst: 40, inend: 50, sz: 11},
+		{fail: true, rev: true, inend: 20, sz: 10},
+		{fail: true, rev: true, inend: 11, sz: 10},
 	} {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
 			orr := ObjectRangeRequest{Start: tc.inst, End: tc.inend, FromEnd: tc.rev}

--- a/range_test.go
+++ b/range_test.go
@@ -1,0 +1,47 @@
+package gofakes3
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRangeRequest(t *testing.T) {
+	for idx, tc := range []struct {
+		inst, inend  int64
+		rev          bool
+		sz           int64
+		outst, outln int64
+		fail         bool
+	}{
+		{inst: 0, inend: RangeNoEnd, sz: 5, outst: 0, outln: 5},
+		{inst: 0, inend: 5, sz: 10, outst: 0, outln: 6},
+		{inst: 0, inend: 5, sz: 4, outst: 0, outln: 4},
+		{inst: 0, inend: 0, sz: 4, outst: 0, outln: 1},
+		{inst: 1, inend: 5, sz: 10, outst: 1, outln: 5},
+
+		{rev: true, inend: 10, sz: 10, outst: 0, outln: 10},
+		{rev: true, inend: 5, sz: 10, outst: 5, outln: 5},
+		{rev: true, inend: 20, sz: 10, outst: 0, outln: 10},
+
+		{fail: true, inst: 0, inend: 0, sz: 0, outst: 0, outln: 0},
+		{fail: true, inst: 10, inend: 15, sz: 10, outst: 10, outln: 0},
+		{fail: true, inst: 40, inend: 50, sz: 11, outst: 11, outln: 0},
+	} {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			orr := ObjectRangeRequest{Start: tc.inst, End: tc.inend, FromEnd: tc.rev}
+
+			rng, err := orr.Range(tc.sz)
+			if tc.fail != (err != nil) {
+				t.Fatal("failure expected:", tc.fail, "found:", err)
+			}
+			if !tc.fail {
+				if rng.Start != tc.outst {
+					t.Fatal("unexpected start:", rng.Start, "expected:", tc.outst)
+				}
+				if rng.Length != tc.outln {
+					t.Fatal("unexpected length:", rng.Length, "expected:", tc.outln)
+				}
+			}
+		})
+	}
+}

--- a/uploader.go
+++ b/uploader.go
@@ -457,9 +457,8 @@ func (mpu *multipartUpload) AddPart(partNumber int, at time.Time, body []byte) (
 
 	// What the ETag actually is is not specified, so let's just invent any old thing
 	// from guaranteed unique input:
-	key := fmt.Sprintf("%s/%s/%s/%d", mpu.Bucket, mpu.Object, mpu.ID, partNumber)
 	hash := md5.New()
-	hash.Write([]byte(key))
+	hash.Write([]byte(body))
 	etag = fmt.Sprintf(`"%s"`, hex.EncodeToString(hash.Sum(nil)))
 
 	part := multipartUploadPart{

--- a/util.go
+++ b/util.go
@@ -14,7 +14,7 @@ func parseClampedInt(in string, defaultValue, min, max int64) (int64, error) {
 		var err error
 		v, err = strconv.ParseInt(in, 10, 0)
 		if err != nil {
-			return defaultValue, err
+			return defaultValue, ErrInvalidArgument
 		}
 	}
 


### PR DESCRIPTION
This implements pagination for both versions of the "list bucket" API:

- https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
- https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html

I'm using a bit of a trick with the ContinuationToken to save backend implementers from having to implement this twice; all the S3-mandated hacks are pushed into GoFakeS3.

Only the memory backend implements the pagination for now; I'm still trying to think of a good way to do it in the bolt backend. I might try and do that as a separate PR.

~NOTE - this PR is based on #28 and depends on that merge, so it should stay WIP until that one has made it through review into master.~

TODO:

- [x] Tests