### PR TITLE
Initial parts for persistent multi-part uploads

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -246,7 +246,7 @@ type MultipartBackend interface {
 	// CompleteMultipart was called.
 	//
 	// The Etag property of the created object may be randomly generated
-	InitiateMultipart(bucketName, key string, meta map[string]string, initiated time.Time) (backendMultipartUpload, error)
+	InitiateMultipart(bucketName, key string, meta map[string]string, initiated time.Time) (MultipartBackendUpload, error)
 
 	// PutMultipart should assume that the key is valid. The partNumber should not yet exist.
 	//
@@ -274,7 +274,7 @@ type MultipartBackend interface {
 	// It also is the backend's responsibility the uploadID replaces the current version of the object
 	//
 	// This is the point after which the key should be visible and retrievable via `GetObject`
-	CompleteMultipart(bucket, key string, id UploadID) (backendMultipartUpload, error)
+	CompleteMultipart(bucket, key string, id UploadID, input *CompleteMultipartUploadRequest) (MultipartBackendUpload, error)
 
 	// ListOngoingMultiparts should assume that the key is valid.
 	ListOngoingMultiparts(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error)
@@ -282,7 +282,7 @@ type MultipartBackend interface {
 	ListOngoingMultipartParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error)
 }
 
-type backendMultipartUpload struct {
+type MultipartBackendUpload struct {
 	ID        UploadID
 	Bucket    string
 	Object    string

--- a/backend/s3afero/backend_test.go
+++ b/backend/s3afero/backend_test.go
@@ -70,8 +70,8 @@ func TestPutGet(t *testing.T) {
 			if obj.Size != int64(len(contents)) {
 				t.Fatal(obj.Size, "!=", len(contents))
 			}
-			if !bytes.Equal(obj.Hash, hash) {
-				t.Fatal(hex.EncodeToString(obj.Hash), "!=", hex.EncodeToString(hash))
+			if !bytes.Equal(obj.ETag, hash) {
+				t.Fatal(hex.EncodeToString(obj.ETag), "!=", hex.EncodeToString(hash))
 			}
 		})
 	}
@@ -116,8 +116,8 @@ func TestPutGetRange(t *testing.T) {
 			if obj.Size != int64(len(contents)) {
 				t.Fatal(obj.Size, "!=", len(contents))
 			}
-			if !bytes.Equal(obj.Hash, hash) {
-				t.Fatal(hex.EncodeToString(obj.Hash), "!=", hex.EncodeToString(hash))
+			if !bytes.Equal(obj.ETag, hash) {
+				t.Fatal(hex.EncodeToString(obj.ETag), "!=", hex.EncodeToString(hash))
 			}
 		})
 	}

--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -297,7 +297,7 @@ func (db *MultiBucketBackend) HeadObject(bucketName, objectName string) (*gofake
 
 	return &gofakes3.Object{
 		Name:     objectName,
-		Hash:     meta.Hash,
+		ETag:     meta.Hash,
 		Metadata: meta.Meta,
 		Size:     size,
 		Contents: s3io.NoOpReadCloser{},
@@ -359,7 +359,7 @@ func (db *MultiBucketBackend) GetObject(bucketName, objectName string, rangeRequ
 
 	return &gofakes3.Object{
 		Name:     objectName,
-		Hash:     meta.Hash,
+		ETag:     meta.Hash,
 		Metadata: meta.Meta,
 		Range:    rnge,
 		Size:     size,

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -221,7 +221,7 @@ func (db *SingleBucketBackend) HeadObject(bucketName, objectName string) (*gofak
 
 	return &gofakes3.Object{
 		Name:     objectName,
-		Hash:     meta.Hash,
+		ETag:     meta.Hash,
 		Metadata: meta.Meta,
 		Size:     size,
 		Contents: s3io.NoOpReadCloser{},
@@ -277,7 +277,7 @@ func (db *SingleBucketBackend) GetObject(bucketName, objectName string, rangeReq
 
 	return &gofakes3.Object{
 		Name:     objectName,
-		Hash:     meta.Hash,
+		ETag:     meta.Hash,
 		Metadata: meta.Meta,
 		Size:     size,
 		Range:    rnge,

--- a/backend/s3bolt/multipart.go
+++ b/backend/s3bolt/multipart.go
@@ -1,28 +1,22 @@
 package s3bolt
 
 import (
-	"bytes"
 	"crypto/rand"
+	"crypto/sha512"
 	"fmt"
+	"github.com/boltdb/bolt"
 	"github.com/johannesboyne/gofakes3"
+	"gopkg.in/mgo.v2/bson"
 	"io"
-	"sync"
+	"strconv"
 	"time"
 )
 
 type upload struct {
 	gofakes3.MultipartBackendUpload
-	sync.Mutex
-	parts map[string]*part
+	Parts map[string]string // Keys are ints, but BSON requires string. use`strconv.Itoa()`
+	Sizes map[string]int64  // Same as above, keys have to match!
 }
-
-type part struct {
-	content    []byte
-	size       int64
-	partNumber int
-}
-
-var uploads = map[string]*upload{}
 
 func randomString(chars int) string {
 	buf := make([]byte, chars/2)
@@ -30,9 +24,26 @@ func randomString(chars int) string {
 	return fmt.Sprintf("%x", buf)
 }
 
-func (db *Backend) InitiateMultipart(bucketName, key string, meta map[string]string, initiated time.Time) (gofakes3.MultipartBackendUpload, error) {
+const BUCKET_PREFIX = "__INTERNAL__s3bolt__"
+const UPLOAD_BUCKET = BUCKET_PREFIX + "uploads"
+const DATA_BUCKET = BUCKET_PREFIX + "data"
 
-	obj := gofakes3.MultipartBackendUpload{
+func uploadMatchesObject(bucket string, key string, up *upload) bool {
+	if up == nil {
+		return false
+	}
+	if up.Bucket != bucket {
+		return false
+	}
+	if up.Object != key {
+		return false
+	}
+	return true
+}
+
+func (db *Backend) InitiateMultipart(bucketName, key string, meta map[string]string, initiated time.Time) (obj gofakes3.MultipartBackendUpload, err error) {
+
+	obj = gofakes3.MultipartBackendUpload{
 		ID:        gofakes3.UploadID(randomString(32)),
 		Bucket:    bucketName,
 		Object:    key,
@@ -41,99 +52,236 @@ func (db *Backend) InitiateMultipart(bucketName, key string, meta map[string]str
 	}
 	up := upload{
 		MultipartBackendUpload: obj,
-		Mutex:                  sync.Mutex{},
-		parts:                  map[string]*part{},
+		Parts:                  map[string]string{},
+		Sizes:                  map[string]int64{},
 	}
-	uploads[string(obj.ID)] = &up
 
-	fmt.Printf("%+v\n", up)
+	err = db.setUpload(obj.ID, &up)
+	if err != nil {
+		return
+	}
 
 	return obj, nil
 }
 
-func (db *Backend) PutMultipart(_, _ string, id gofakes3.UploadID, partNumber int, input io.Reader, size int64) (string, error) {
-	data, err := gofakes3.ReadAll(input, size)
+func (db *Backend) getUpload(id gofakes3.UploadID) (*upload, error) {
+	var data []byte
+	var up upload
+	err := db.getBlob(UPLOAD_BUCKET, string(id), &data)
 	if err != nil {
-		return "", err
+		return nil, gofakes3.ErrNoSuchUpload
 	}
-	uploads[string(id)].Lock()
-	defer uploads[string(id)].Unlock()
-
-	etag := randomString(48)
-
-	uploads[string(id)].parts[etag] = &part{
-		size:       size,
-		content:    data,
-		partNumber: partNumber,
+	err = bson.Unmarshal(data, &up)
+	if err != nil {
+		return nil, err
 	}
-
-	fmt.Printf("ETag: %s, upload size: %d\n", etag, uploads[string(id)].parts[etag].size)
-
-	return etag, gofakes3.ErrNotImplemented
+	if up.Parts == nil {
+		up.Parts = map[string]string{}
+	}
+	if up.Sizes == nil {
+		up.Sizes = map[string]int64{}
+	}
+	return &up, nil
 }
 
-func (db *Backend) AbortMultipart(_, _ string, id gofakes3.UploadID) error {
-	delete(uploads, string(id)) // No-op if not existent
-
-	return nil
-}
-
-func (db *Backend) CompleteMultipart(_, _ string, id gofakes3.UploadID, input *gofakes3.CompleteMultipartUploadRequest) (ret gofakes3.MultipartBackendUpload, err error) {
-	var ok bool
-	var up *upload
-	var size int64
-	var last int
-	var readers []io.Reader
-
-	if up, ok = uploads[string(id)]; !ok {
-		err = gofakes3.ErrInvalidPart
+func (db *Backend) setUpload(id gofakes3.UploadID, up *upload) (err error) {
+	var data []byte
+	data, err = bson.Marshal(up)
+	if err != nil {
 		return
 	}
 
+	return db.putBlob(UPLOAD_BUCKET, string(id), &data, true)
+}
+
+// addPartAtomic allows multiple parts to be uploaded simultaneously, because it makes sure there only is one
+// in-flight part-list update at a time
+func (db *Backend) addPartAtomic(id gofakes3.UploadID, partNumber int, etag string, size int64) (err error) {
+	db.Lock()
+	defer db.Unlock()
+
+	var up *upload
+	up, err = db.getUpload(id)
+	if err != nil {
+		return
+	}
+	up.Parts[strconv.Itoa(partNumber)] = etag
+	up.Sizes[strconv.Itoa(partNumber)] = size
+	return db.setUpload(id, up)
+}
+
+func (db *Backend) addChunk(input io.Reader, size int64) (etag string, err error) {
+	var data []byte
+	data, err = gofakes3.ReadAll(input, size)
+	if err != nil {
+		return
+	}
+
+	etag = fmt.Sprintf(`"%x"`, sha512.Sum512(data))
+	err = db.putBlob(DATA_BUCKET, etag, &data, true)
+	return
+}
+
+func (db *Backend) deleteChunk(etag string) (err error) {
+	err = db.bolt.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(DATA_BUCKET))
+		if b != nil {
+			return b.Delete([]byte(etag))
+		}
+		return nil
+	})
+
+	return
+}
+
+func (db *Backend) PutMultipart(bucket, key string, id gofakes3.UploadID, partNumber int, input io.Reader, size int64) (string, error) {
+	up, err := db.getUpload(id)
+	if err != nil {
+		return "", gofakes3.ErrNoSuchUpload
+	}
+
+	if !uploadMatchesObject(bucket, key, up) {
+		return "", gofakes3.ErrNoSuchUpload
+	}
+
+	var etag string
+	etag, err = db.addChunk(input, size)
+	if err != nil {
+		return "", err
+	}
+
+	err = db.addPartAtomic(id, partNumber, etag, size)
+
+	return etag, err
+}
+
+func (db *Backend) AbortMultipart(bucket, key string, id gofakes3.UploadID) error {
+	up, err := db.getUpload(id)
+	if err != nil {
+		return err
+	}
+
+	if !uploadMatchesObject(bucket, key, up) {
+		return gofakes3.ErrNoSuchUpload
+	}
+
+	return db.destroy(id)
+}
+
+func (db *Backend) destroy(id gofakes3.UploadID) (err error) {
+	var up *upload
+	up, err = db.getUpload(id)
+	if err != nil {
+		return
+	}
+
+	for _, etag := range up.Parts {
+		err = db.deleteChunk(etag)
+		if err != nil {
+			return
+		}
+	}
+
+	err = db.bolt.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(UPLOAD_BUCKET))
+		if b != nil {
+			return b.Delete([]byte(id))
+		}
+		return nil
+	})
+	return
+}
+
+func (db *Backend) CompleteMultipart(bucket, key string, id gofakes3.UploadID, input *gofakes3.CompleteMultipartUploadRequest) (ret gofakes3.MultipartBackendUpload, err error) {
+	var up *upload
+	var size int64
+	var last int
+
+	db.Lock()
+	defer db.Unlock()
+	up, err = db.getUpload(id)
+	if err != nil {
+		return
+	}
+
+	if !uploadMatchesObject(bucket, key, up) {
+		err = gofakes3.ErrNoSuchUpload
+		return
+	}
+
+	var chunks []string
+	var chunkSize int64
+
 	for _, part := range input.Parts {
 		if last+1 != part.PartNumber {
-			fmt.Printf("ErrInvalidPartOrder, last: %d, current: %d\n", last, part.PartNumber)
 			err = gofakes3.ErrInvalidPartOrder
 			return
 		}
 		last = part.PartNumber
 
-		if upPart, ok := up.parts[part.ETag]; ok {
-			if upPart.partNumber != part.PartNumber {
-				fmt.Printf("Partnumber mismatch upPart.partNumber: %d, part.PartNumber: %d\n", upPart.partNumber, part.PartNumber)
+		if etag, ok := up.Parts[strconv.Itoa(part.PartNumber)]; ok {
+			if etag != part.ETag {
 				err = gofakes3.ErrInvalidPart
 				return
 			}
-			readers = append(readers, bytes.NewReader(upPart.content))
-			size += upPart.size
+			chunks = append(chunks, etag)
+			size += up.Sizes[strconv.Itoa(part.PartNumber)]
+			if chunkSize < up.Sizes[strconv.Itoa(part.PartNumber)] {
+				chunkSize = up.Sizes[strconv.Itoa(part.PartNumber)]
+			}
 		} else {
-			fmt.Printf("Part with etag %s does not exist\n", part.ETag)
 			err = gofakes3.ErrInvalidPart
 			return
 		}
 	}
 
-	res, err := db.PutObject(
-		uploads[string(id)].Bucket,
-		uploads[string(id)].Object,
-		uploads[string(id)].Meta,
-		io.MultiReader(readers...),
-		size,
-	)
-
+	chunkHash := sha512.Sum512([]byte(fmt.Sprintf("%+v", chunks)))
+	data, err := bson.Marshal(&boltObject{
+		Name:      up.Object,
+		Metadata:  up.Meta,
+		Size:      size,
+		Chunks:    chunks,
+		ChunkSize: chunkSize,
+		Hash:      chunkHash[:],
+	})
 	if err != nil {
 		return
 	}
 
-	ret.ID = id
-	ret.Bucket = uploads[string(id)].Bucket
-	ret.Object = uploads[string(id)].Object
-	ret.Meta = uploads[string(id)].Meta
-	ret.Initiated = uploads[string(id)].Initiated
-	ret.VersionID = res.VersionID
+	var previousBlob []byte
+	var oldChunks []string
+	_ = db.getBlob(up.Bucket, up.Object, &previousBlob)
+	if len(previousBlob) == 0 {
+		// No previous data
+	} else {
+		var previous boltObject
+		err = bson.Unmarshal(previousBlob, &previous)
+		if err != nil {
+			return
+		}
+		oldChunks = previous.Chunks
+	}
 
-	res2, err := db.GetObject(ret.Bucket, ret.Object, nil)
-	ret.ETag = string(res2.ETag)
+	err = db.putBlob(up.Bucket, up.Object, &data, false)
+	if err != nil {
+		return
+	}
+
+	// Delete old chunks only after the new object was stored
+	for _, etag := range oldChunks {
+		err = db.deleteChunk(etag)
+		if err != nil {
+			return
+		}
+	}
+
+	ret.ID = id
+	ret.Bucket = up.Bucket
+	ret.Object = up.Object
+	ret.Meta = up.Meta
+	ret.Initiated = up.Initiated
+	ret.ETag = fmt.Sprintf(`"%x"`, chunkHash[:])
+	err = db.destroy(id)
 
 	return
 }

--- a/backend/s3bolt/multipart.go
+++ b/backend/s3bolt/multipart.go
@@ -1,0 +1,147 @@
+package s3bolt
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"github.com/johannesboyne/gofakes3"
+	"io"
+	"sync"
+	"time"
+)
+
+type upload struct {
+	gofakes3.MultipartBackendUpload
+	sync.Mutex
+	parts map[string]*part
+}
+
+type part struct {
+	content    []byte
+	size       int64
+	partNumber int
+}
+
+var uploads = map[string]*upload{}
+
+func randomString(chars int) string {
+	buf := make([]byte, chars/2)
+	_, _ = rand.Read(buf)
+	return fmt.Sprintf("%x", buf)
+}
+
+func (db *Backend) InitiateMultipart(bucketName, key string, meta map[string]string, initiated time.Time) (gofakes3.MultipartBackendUpload, error) {
+
+	obj := gofakes3.MultipartBackendUpload{
+		ID:        gofakes3.UploadID(randomString(32)),
+		Bucket:    bucketName,
+		Object:    key,
+		Meta:      meta,
+		Initiated: initiated,
+	}
+	up := upload{
+		MultipartBackendUpload: obj,
+		Mutex:                  sync.Mutex{},
+		parts:                  map[string]*part{},
+	}
+	uploads[string(obj.ID)] = &up
+
+	fmt.Printf("%+v\n", up)
+
+	return obj, nil
+}
+
+func (db *Backend) PutMultipart(_, _ string, id gofakes3.UploadID, partNumber int, input io.Reader, size int64) (string, error) {
+	data, err := gofakes3.ReadAll(input, size)
+	if err != nil {
+		return "", err
+	}
+	uploads[string(id)].Lock()
+	defer uploads[string(id)].Unlock()
+
+	etag := randomString(48)
+
+	uploads[string(id)].parts[etag] = &part{
+		size:       size,
+		content:    data,
+		partNumber: partNumber,
+	}
+
+	fmt.Printf("ETag: %s, upload size: %d\n", etag, uploads[string(id)].parts[etag].size)
+
+	return etag, gofakes3.ErrNotImplemented
+}
+
+func (db *Backend) AbortMultipart(_, _ string, id gofakes3.UploadID) error {
+	delete(uploads, string(id)) // No-op if not existent
+
+	return nil
+}
+
+func (db *Backend) CompleteMultipart(_, _ string, id gofakes3.UploadID, input *gofakes3.CompleteMultipartUploadRequest) (ret gofakes3.MultipartBackendUpload, err error) {
+	var ok bool
+	var up *upload
+	var size int64
+	var last int
+	var readers []io.Reader
+
+	if up, ok = uploads[string(id)]; !ok {
+		err = gofakes3.ErrInvalidPart
+		return
+	}
+
+	for _, part := range input.Parts {
+		if last+1 != part.PartNumber {
+			fmt.Printf("ErrInvalidPartOrder, last: %d, current: %d\n", last, part.PartNumber)
+			err = gofakes3.ErrInvalidPartOrder
+			return
+		}
+		last = part.PartNumber
+
+		if upPart, ok := up.parts[part.ETag]; ok {
+			if upPart.partNumber != part.PartNumber {
+				fmt.Printf("Partnumber mismatch upPart.partNumber: %d, part.PartNumber: %d\n", upPart.partNumber, part.PartNumber)
+				err = gofakes3.ErrInvalidPart
+				return
+			}
+			readers = append(readers, bytes.NewReader(upPart.content))
+			size += upPart.size
+		} else {
+			fmt.Printf("Part with etag %s does not exist\n", part.ETag)
+			err = gofakes3.ErrInvalidPart
+			return
+		}
+	}
+
+	res, err := db.PutObject(
+		uploads[string(id)].Bucket,
+		uploads[string(id)].Object,
+		uploads[string(id)].Meta,
+		io.MultiReader(readers...),
+		size,
+	)
+
+	if err != nil {
+		return
+	}
+
+	ret.ID = id
+	ret.Bucket = uploads[string(id)].Bucket
+	ret.Object = uploads[string(id)].Object
+	ret.Meta = uploads[string(id)].Meta
+	ret.Initiated = uploads[string(id)].Initiated
+	ret.VersionID = res.VersionID
+
+	res2, err := db.GetObject(ret.Bucket, ret.Object, nil)
+	ret.ETag = string(res2.ETag)
+
+	return
+}
+
+func (db *Backend) ListOngoingMultiparts(bucket string, marker *gofakes3.UploadListMarker, prefix gofakes3.Prefix, limit int64) (*gofakes3.ListMultipartUploadsResult, error) {
+	return nil, gofakes3.ErrNotImplemented
+}
+
+func (db *Backend) ListOngoingMultipartParts(bucket, object string, uploadID gofakes3.UploadID, marker int, limit int64) (*gofakes3.ListMultipartUploadPartsResult, error) {
+	return nil, gofakes3.ErrNotImplemented
+}

--- a/backend/s3bolt/schema.go
+++ b/backend/s3bolt/schema.go
@@ -47,7 +47,7 @@ func (b *boltObject) Object(objectName string, rangeRequest *gofakes3.ObjectRang
 		Size:     b.Size,
 		Contents: s3io.ReaderWithDummyCloser{bytes.NewReader(data)},
 		Range:    rnge,
-		Hash:     b.Hash,
+		ETag:     b.Hash,
 	}, nil
 }
 

--- a/backend/s3mem/bucket.go
+++ b/backend/s3mem/bucket.go
@@ -150,13 +150,13 @@ func (bi *bucketData) toObject(rangeRequest *gofakes3.ObjectRangeRequest, withBo
 
 	return &gofakes3.Object{
 		Name:           bi.name,
-		Hash:           bi.hash,
+		ETag:           bi.hash,
 		Metadata:       bi.metadata,
 		Size:           sz,
 		Range:          rnge,
 		IsDeleteMarker: bi.deleteMarker,
 		VersionID:      bi.versionID,
-		Contents:       contents,
+		Contents: contents,
 	}, nil
 }
 

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -779,7 +779,7 @@ func (g *GoFakeS3) completeMultipartUpload(bucket, object string, uploadID Uploa
 	var version VersionID
 
 	if mpb, ok := g.storage.(MultipartBackend); ok {
-		upload, err := mpb.CompleteMultipart(bucket, object, uploadID)
+		upload, err := mpb.CompleteMultipart(bucket, object, uploadID, &in)
 		if err != nil {
 			return err
 		}

--- a/hash.go
+++ b/hash.go
@@ -55,7 +55,7 @@ func (h *hashingReader) Read(p []byte) (n int, err error) {
 	n, err = h.inner.Read(p)
 
 	if n != 0 {
-		wn, _ := h.hash.Write(p[:n]) // Hash.Write never returns an error.
+		wn, _ := h.hash.Write(p[:n]) // ETag.Write never returns an error.
 		if wn != n {
 			return n, fmt.Errorf("short write to hasher")
 		}

--- a/init_test.go
+++ b/init_test.go
@@ -598,6 +598,7 @@ func (ts *testServer) assertObject(bucket string, object string, meta map[string
 
 	obj, err := ts.backend.GetObject(bucket, object, nil)
 	ts.OK(err)
+
 	defer obj.Contents.Close()
 
 	data, err := gofakes3.ReadAll(obj.Contents, obj.Size)


### PR DESCRIPTION
 * Renamed `Object.Hash` to `Object.ETag` as there is no way to get the hash of the file without re-reading the entire file. This is not desirable if the backend is slow. I could only find usages where this is used as an ETag, so I figured naming it as such is not too bad.
 * Add `MultipartBackend` interface with an outline of what may come. (very much subject to change) If a backend implements this, it will become the decision-maker to not use in-memory multipart uploads and instead use the backend. If it is not implemented by a backend the bahaviour will be unchanged.
 * Implemented rough sketch of web-facing code to make use of the `MultipartBackend`
 * Implemented `MultiReadCloser` as a ReadCloser alternative to `io.MultiReader`.

Data up- & download still works as previously (tested with `bolt` backend and aws cli)