### PR TITLE
Incorrect range handling for some edge cases

### DIFF
--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -311,14 +311,14 @@ func TestGetObjectRange(t *testing.T) {
 		{"bytes=0-1", in[:2], false},
 		{"bytes=1023-1023", in[1023:1024], false},
 
-		// if the requested end is beyond the real end, it should fail
-		{"bytes=1023-1024", in[1023:1024], true},
+		// if the requested end is beyond the real end, returns "remainder of the representation"
+		{"bytes=1023-1025", in[1023:1024], false},
 
 		// if the requested start is beyond the real end, it should fail
 		{"bytes=1024-1024", []byte{}, true},
 
 		// suffix-byte-range-spec:
-		{"bytes=-0", []byte{}, false},
+		{"bytes=-0", []byte{}, true},
 		{"bytes=-1", in[1023:1024], false},
 		{"bytes=-1024", in, false},
 		{"bytes=-1025", in, true},

--- a/range.go
+++ b/range.go
@@ -53,8 +53,12 @@ func (o *ObjectRangeRequest) Range(size int64) (*ObjectRange, error) {
 		length = size - start
 	}
 
-	if start < 0 || length < 0 || start > size || start+length > size {
+	if start < 0 || length < 0 || start >= size {
 		return nil, ErrInvalidRange
+	}
+
+	if start+length > size {
+		return &ObjectRange{Start: start, Length: size - start}, nil
 	}
 
 	return &ObjectRange{Start: start, Length: length}, nil

--- a/range_test.go
+++ b/range_test.go
@@ -17,16 +17,19 @@ func TestRangeRequest(t *testing.T) {
 		{inst: 0, inend: 5, sz: 10, outst: 0, outln: 6},
 		{inst: 0, inend: 0, sz: 4, outst: 0, outln: 1},
 		{inst: 1, inend: 5, sz: 10, outst: 1, outln: 5},
+		{inst: 1, inend: 5, sz: 3, outst: 1, outln: 2},
+		{inst: 5, inend: 7, sz: 6, outst: 5, outln: 1},
 
 		{rev: true, inend: 10, sz: 10, outst: 0, outln: 10},
 		{rev: true, inend: 5, sz: 10, outst: 5, outln: 5},
 
 		{fail: true, inst: 0, inend: 0, sz: 0},
-		{fail: true, inst: 0, inend: 5, sz: 4},
+		{fail: true, inst: 1, inend: 1, sz: 1},
 		{fail: true, inst: 10, inend: 15, sz: 10},
 		{fail: true, inst: 40, inend: 50, sz: 11},
 		{fail: true, rev: true, inend: 20, sz: 10},
 		{fail: true, rev: true, inend: 11, sz: 10},
+		{fail: true, rev: true, inend: 0, sz: 10}, // zero suffix-length is not satisfiable
 	} {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
 			orr := ObjectRangeRequest{Start: tc.inst, End: tc.inend, FromEnd: tc.rev}


### PR DESCRIPTION
Why:

Incorrect range handling cases causes s3manager downloads to fail.

* When end extends beyond available data it should return data from
  "start" to the end of the available data. Currently it returns
  invalid range error.

  From RFC-7233:

  > If the last-byte-pos value is.. greater than or equal to the current
  > length of the representation data, the byte range is interpreted as
  > the remainder of the representation (i.e., the server replaces the
  > value of last-byte-pos with a value that is one less than the current
  > length of the selected representation).

* A "-0" suffix byte range is "not satisfiable" according to RFC and
  should return an invalid range error. Currently it just returns an
  empty data set.

  Also from RFC-7233:

  > If a valid byte-range-set includes ... or at least one
  > suffix-byte-range-spec with a non-zero suffix-length, then the
  > byte-range-set is satisfiable.  Otherwise, the byte-range-set is
  > unsatisfiable.

Fixes Issue #36 