### PR TITLE
PutObject support for zero-length files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/johannesboyne/gofakes3
 
+go 1.12
+
 require (
 	github.com/aws/aws-sdk-go v1.17.4
 	github.com/boltdb/bolt v1.3.1

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -529,9 +529,15 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 		return err
 	}
 
-	size, err := strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
-	if err != nil || size <= 0 {
+	contentLength := r.Header.Get("Content-Length")
+	if contentLength == "" {
 		return ErrMissingContentLength
+	}
+
+	size, err := strconv.ParseInt(contentLength, 10, 64)
+	if err != nil || size < 0 {
+		w.WriteHeader(http.StatusBadRequest) // XXX: no code for this, according to s3tests
+		return nil
 	}
 
 	if len(object) > KeySizeLimit {

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -182,6 +182,22 @@ func TestCreateObjectMD5(t *testing.T) {
 	}
 }
 
+func TestCreateObjectWithMissingContentLength(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	client := ts.rawClient()
+	body := []byte{}
+	rq, err := http.NewRequest("PUT", client.URL(fmt.Sprintf("/%s/yep", defaultBucket)).String(), maskReader(bytes.NewReader(body)))
+	if err != nil {
+		panic(err)
+	}
+	client.SetHeaders(rq, body)
+	rs, _ := client.Do(rq)
+	if rs.StatusCode != http.StatusLengthRequired {
+		t.Fatal()
+	}
+}
+
 func TestDeleteBucket(t *testing.T) {
 	t.Run("delete-empty", func(t *testing.T) {
 		ts := newTestServer(t, withoutInitialBuckets())

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -1,6 +1,7 @@
 package gofakes3_test
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/xml"
 	"fmt"
@@ -195,6 +196,35 @@ func TestCreateObjectWithMissingContentLength(t *testing.T) {
 	rs, _ := client.Do(rq)
 	if rs.StatusCode != http.StatusLengthRequired {
 		t.Fatal()
+	}
+}
+
+func TestCreateObjectWithInvalidContentLength(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	client := ts.rawClient()
+
+	body := []byte{1, 2, 3}
+	rq, err := http.NewRequest("PUT", client.URL(fmt.Sprintf("/%s/yep", defaultBucket)).String(), maskReader(bytes.NewReader(body)))
+	if err != nil {
+		panic(err)
+	}
+
+	client.SetHeaders(rq, body)
+	rq.Header.Set("Content-Length", "quack")
+	raw, err := client.SendRaw(rq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rs, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(raw)), rq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rs.Body.Close()
+
+	if rs.StatusCode != http.StatusBadRequest {
+		t.Fatal(rs.StatusCode, "!=", http.StatusBadRequest)
 	}
 }
 


### PR DESCRIPTION
Fixes #41

An easy fix, but hard to test! The Go http client tries very hard to force `Content-Length`, which is great until you need it to not do that :joy: 

Thanks, @onemorezero!