### PR TITLE
Support multipart uploads from browser

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -17,10 +17,12 @@ var (
 		"X-Amz-User-Agent",
 		"X-CSRF-Token",
 		"x-amz-acl",
+		"x-amz-content-sha256",
 		"x-amz-meta-filename",
 		"x-amz-meta-from",
 		"x-amz-meta-private",
 		"x-amz-meta-to",
+		"x-amz-security-token",
 	}
 	corsHeadersString = strings.Join(corsHeaders, ", ")
 )
@@ -34,6 +36,7 @@ func (s *withCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, HEAD")
 	w.Header().Set("Access-Control-Allow-Headers", corsHeadersString)
+	w.Header().Set("Access-Control-Expose-Headers", "ETag")
 
 	if r.Method == "OPTIONS" {
 		return


### PR DESCRIPTION
This PR adds support for browser multipart uploads using Temporary Security Credentials.

I am uploading to S3 from the browser using the official AWS JS SDK, https://github.com/aws/aws-sdk-js, and temporary Temporary Security Credentials issued by the back-end, https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html. The code sample is below:

```js
export function basicUploadToS3(
  uploadPermit,
  file,
  onProgress,
  uploadParams = { queueSize: 4, partSize: 10 * 1024 * 1024 },
) {
  const {
    region, bucket, key,
    accessKeyId, secretAccessKey, sessionToken, // issued by the back-end
  } = uploadPermit;

  return new Promise((resolve, reject) => {
    new S3({
      apiVersion: '2006-03-01',
      endpoint: config.upload.s3endpoint,
      correctClockSkew: true,
      maxRetries: 3,
      accessKeyId,
      secretAccessKey,
      sessionToken,
      region,
    }).upload({
      Bucket: bucket,
      Key: key,
      ACL: 'bucket-owner-full-control',
      ContentType: file.type,
      Body: file,
    }, uploadParams, (err, data) => {
      return err ? reject(err) : resolve(data);
    }).on('httpUploadProgress', e => {
      onProgress(e.loaded / e.total);
    });
  });
}
```

This PR makes it possible.