### PR TITLE
Bugfix: do not overwrite the Last-Modified value with the current time

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -432,7 +432,6 @@ func (g *GoFakeS3) writeGetOrHeadObjectResponse(obj *Object, w http.ResponseWrit
 	for mk, mv := range obj.Metadata {
 		w.Header().Set(mk, mv)
 	}
-	w.Header().Set("Last-Modified", formatHeaderTime(g.timeSource.Now()))
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("ETag", `"`+hex.EncodeToString(obj.Hash)+`"`)
 


### PR DESCRIPTION
in GET and HEAD calls, use the stored value instead.