### PR TITLE
Remove etag quotes when completing a multipart upload.

### DIFF
--- a/uploader.go
+++ b/uploader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -499,7 +500,7 @@ func (mpu *multipartUpload) Reassemble(input *CompleteMultipartUploadRequest) (b
 		}
 
 		upPart := mpu.parts[inPart.PartNumber]
-		if inPart.ETag != upPart.ETag {
+		if strings.Trim(inPart.ETag, "\"") != strings.Trim(upPart.ETag, "\"") {
 			return nil, "", ErrorMessagef(ErrInvalidPart, "unexpected part etag for number %d in complete request", inPart.PartNumber)
 		}
 


### PR DESCRIPTION
The minio s3 client fails when completing a multipart upload. The check on gofakes3.go:502 fails, since
the etag in the xml document is not quoted and the etag from the header is.

This is an attempt at addressing #51 