### PR TITLE
unescape 'X-Amz-Copy-Source' value before using

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -617,6 +617,10 @@ func (g *GoFakeS3) copyObject(bucket, object string, meta map[string]string, w h
 	srcBucket := parts[0]
 	srcKey := strings.SplitN(parts[1], "?", 2)[0]
 
+	srcKey, err = url.QueryUnescape(srcKey)
+	if err != nil {
+		return err
+	}
 	srcObj, err := g.storage.GetObject(srcBucket, srcKey, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
According to [aws docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html)  `x-amz-copy-source` value must be URL encoded.
If source key has special chars, the client should url encode the `CopySource` field of `s3.CopyObjectInput`. 
If source key is not decoded, successive calls to `GetObject` with the same key results in `404 Not Found` errors.

Here is a little background about this PR:

`s5cmd` integration tests use `gofakes3`. There is an issue about  special chars which will be resolved with this PR : https://github.com/peak/s5cmd/pull/280. The implementation in this PR works fine with real s3 service but tests that use gofakes3 fails with 404 errors.
