### PR TITLE
Add Content-Type to metadataHeaders

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -998,7 +998,7 @@ func metadataSize(meta map[string]string) int {
 func metadataHeaders(headers map[string][]string, at time.Time, sizeLimit int) (map[string]string, error) {
 	meta := make(map[string]string)
 	for hk, hv := range headers {
-		if strings.HasPrefix(hk, "X-Amz-") {
+		if strings.HasPrefix(hk, "X-Amz-") || hk == "Content-Type" {
 			meta[hk] = hv[0]
 		}
 	}


### PR DESCRIPTION
HeadObject doesn't return a content-type without this change