### PR TITLE
unmarshall to boltobject before listing

### DIFF
--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -159,12 +159,16 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 				objects.AddPrefix(match.MatchedPart)
 
 			} else {
-				hash := md5.Sum(v)
+				var b boltObject
+				err := bson.Unmarshal(v, &b)
+				if err != nil {
+					return fmt.Errorf("gofakes3: could not unmarshal object %q: %v", string(k[:]), err)
+				}
 				item := &gofakes3.Content{
-					Key:          string(k),
+					Key:          string(k[:]),
 					LastModified: mod,
-					ETag:         `"` + hex.EncodeToString(hash[:]) + `"`,
-					Size:         int64(len(v)),
+					ETag:         `"` + hex.EncodeToString(b.Hash[:]) + `"`,
+					Size:         b.Size,
 				}
 				objects.Add(item)
 			}


### PR DESCRIPTION
Hi,

We are using `gofakes3` testing for [s5cmd](https://github.com/peak/s5cmd) so thank you for this amazing project. When we are testing, we noticed something probably a bug.

`gofakes3` shows object sizes larger than it should be.

For example, let's say we have a file named `file.txt`
```
> echo "this is a file content" > file.txt
```
If we check the size it says, it is 23 bytes.
```
> ls -lah file.txt
-rw-r--r-- 1 hasan hasan 23 Aug 17 10:50 file.txt
```
But in s5cmd, if we put this object to a bucket, then get object with `ListBucket` method. It will give us size of 317 bytes. I tried to debug the issue and find out:
1.  when `gofakes3` puts an object, first it converts whole object to an array using `bson.Marshall` method. 
2. Then it puts the whole converted array to object
3. When listing objects it puts the size of whole array, therefore, `gofakes3` shows file size larger than it should be. You can check it from [here](https://github.com/johannesboyne/gofakes3/blob/master/backend/s3bolt/backend.go#L167).

My suggestion is that we need to unmarshall the converted array, then use this unmarshalled object. 

`gofakes3` uses unmarshall just before `GetObject` function. And the results are correct in that case (file size is correct etc). You can check it from [here](https://github.com/johannesboyne/gofakes3/blob/master/backend/s3bolt/backend.go#L275-L279). I think if we do the same process in `ListBucket` function, we will have no problem.