### PR TITLE
Add test for unmarshall to bolt object before listing.

### DIFF
--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -130,7 +130,7 @@ func TestListBucketObjectSize(t *testing.T) {
 	ts.OK(err)
 
 	if *output.Contents[0].Size != int64(5) {
-		ts.Fatalf("Size wanted 5 got :%v\n", output.Contents[0].Size)
+		ts.Fatalf("Size wanted 5 got :%v\n", *output.Contents[0].Size)
 	}
 }
 

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -110,6 +110,30 @@ func TestListBuckets(t *testing.T) {
 	assertBucketTime("test3", defaultDate.Add(1*time.Minute))
 }
 
+func TestListBucketObjectSize(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(defaultBucket),
+		Key:    aws.String("object"),
+		Body:   bytes.NewReader([]byte("hello")), // size 5
+	})
+	ts.OK(err)
+
+	listInput := s3.ListObjectsV2Input{
+		Bucket: aws.String(defaultBucket),
+	}
+
+	output, err := svc.ListObjectsV2(&listInput) // there should be only 1 object
+	ts.OK(err)
+
+	if *output.Contents[0].Size != int64(5) {
+		ts.Fatalf("Size wanted 5 got :%v\n", output.Contents[0].Size)
+	}
+}
+
 func TestCreateObject(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Close()


### PR DESCRIPTION
Hello,

Thank you for accepting my previous [PR](https://github.com/johannesboyne/gofakes3/pull/57). Like you suggested at the end, I tried to add a small test case which shows that after listing objects, the object sizes are correct. 

Also I figured that, `gofakes3` does not show real modification time when `ListBucket` is called. So I tried to solve this problem with,
1. Put modification time into `boltObject` when `putObject` is called.
2. Then unmarshall it when listing is called.

Then, we can see the real times which shows the time object is uploaded.