### PR TITLE
Implement conditional caching

### DIFF
--- a/error.go
+++ b/error.go
@@ -83,6 +83,9 @@ const (
 
 	ErrNoSuchVersion ErrorCode = "NoSuchVersion"
 
+	// No need to retransmit the object
+	ErrNotModified ErrorCode = "NotModified"
+
 	ErrRequestTimeTooSkewed ErrorCode = "RequestTimeTooSkewed"
 	ErrTooManyBuckets       ErrorCode = "TooManyBuckets"
 	ErrNotImplemented       ErrorCode = "NotImplemented"
@@ -267,6 +270,9 @@ func (e ErrorCode) Status() int {
 
 	case ErrNotImplemented:
 		return http.StatusNotImplemented
+
+	case ErrNotModified:
+		return http.StatusNotModified
 
 	case ErrMissingContentLength:
 		return http.StatusLengthRequired

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -565,9 +565,8 @@ func TestGetObjectIfNoneMatch(t *testing.T) {
 	assertModified := func(ts *testServer, ifNoneMatch string, shouldModify bool) {
 		svc := ts.s3Client()
 		input := s3.GetObjectInput{
-			Bucket:      aws.String(defaultBucket),
-			Key:         aws.String(objectKey),
-			IfNoneMatch: aws.String(ifNoneMatch),
+			Bucket: aws.String(defaultBucket),
+			Key:    aws.String(objectKey),
 		}
 		if ifNoneMatch != "" {
 			input.IfNoneMatch = aws.String(ifNoneMatch)

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -560,6 +560,53 @@ func TestGetObjectRangeInvalid(t *testing.T) {
 	}
 }
 
+func TestGetObjectIfNoneMatch(t *testing.T) {
+	objectKey := "foo"
+	assertModified := func(ts *testServer, ifNoneMatch string, shouldModify bool) {
+		svc := ts.s3Client()
+		input := s3.GetObjectInput{
+			Bucket:      aws.String(defaultBucket),
+			Key:         aws.String(objectKey),
+			IfNoneMatch: aws.String(ifNoneMatch),
+		}
+		if ifNoneMatch != "" {
+			input.IfNoneMatch = aws.String(ifNoneMatch)
+		}
+
+		_, err := svc.GetObject(&input)
+		modified := true
+		if err != nil {
+			if !s3HasErrorCode(err, gofakes3.ErrNotModified) {
+				ts.Fatal("get-object-failed", err)
+			}
+
+			modified = false
+		}
+
+		if modified != shouldModify {
+			ts.Fatal("expected modified", shouldModify, "found", modified)
+		}
+	}
+
+	for idx, tc := range []struct {
+		ifNoneMatch  string
+		shouldModify bool
+	}{
+		{shouldModify: true},
+		{ifNoneMatch: `"5d41402abc4b2a76b9719d911017c592"`, shouldModify: false}, // md5("hello")
+		{ifNoneMatch: `"notTheSameEtag"`, shouldModify: true},
+	} {
+		t.Run(fmt.Sprintf("%d/%s", idx, tc.ifNoneMatch), func(t *testing.T) {
+			ts := newTestServer(t)
+			defer ts.Close()
+
+			ts.backendPutString(defaultBucket, objectKey, nil, "hello")
+
+			assertModified(ts, tc.ifNoneMatch, tc.shouldModify)
+		})
+	}
+}
+
 func TestCreateObjectBrowserUpload(t *testing.T) {
 	addFile := func(tt gofakes3.TT, w *multipart.Writer, object string, b []byte) {
 		tt.Helper()


### PR DESCRIPTION
The S3 API allows conditional caching by sending a `If-None-Match` Header with GET or HEAD object requests. If the value provided with the Header matches the Etag of the object, a `304 Not Modified` response is returned.

> **If-None-Match**
> Return the object only if its entity tag (ETag) is different from the one specified; otherwise, return a 304 (not modified) error.

from the [GetObject docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax)

This PR implements that behavior. S3 allows for more complex conditional caching as well:

> **Additional Considerations about Request Headers**
>
> If both of the `If-Match` and `If-Unmodified-Since` headers are present in the request as follows: `If-Match` condition evaluates to `true`, and; `If-Unmodified-Since` condition evaluates to `false`; then, S3 returns 200 OK and the data requested.
>
> If both of the `If-None-Match` and `If-Modified-Since` headers are present in the request as follows: `If-None-Match` condition evaluates to `false`, and; `If-Modified-Since` condition evaluates to `true`; then, S3 returns 304 Not Modified response code.

Especially the `If-Modified-Since` Header may be of use and I could add it to this PR.
