### PR TITLE
Add Content-Disposition to metadata headers

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -1006,7 +1006,7 @@ func metadataSize(meta map[string]string) int {
 func metadataHeaders(headers map[string][]string, at time.Time, sizeLimit int) (map[string]string, error) {
 	meta := make(map[string]string)
 	for hk, hv := range headers {
-		if strings.HasPrefix(hk, "X-Amz-") || hk == "Content-Type" {
+		if strings.HasPrefix(hk, "X-Amz-") || hk == "Content-Type" || hk == "Content-Disposition" {
 			meta[hk] = hv[0]
 		}
 	}

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -253,6 +253,31 @@ func TestCreateObjectWithInvalidContentLength(t *testing.T) {
 	}
 }
 
+func TestCreateObjectWithContentDisposition(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket:             aws.String(defaultBucket),
+		Key:                aws.String("object"),
+		Body:               bytes.NewReader([]byte("hello")),
+		ContentDisposition: aws.String("inline; filename=hello_world.txt"),
+	})
+	ts.OK(err)
+
+	obj, err := svc.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(defaultBucket),
+		Key:    aws.String("object"),
+	})
+	if obj.ContentDisposition == nil {
+		t.Fatal("missing Content-Disposition")
+	}
+	if *obj.ContentDisposition != "inline; filename=hello_world.txt" {
+		t.Fatal("Content-Disposition does not match")
+	}
+}
+
 func TestCopyObject(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Close()


### PR DESCRIPTION
Setting the Content-Disposition when creating an object is now added to the object metadata.

Fixes #61