### PR TITLE
Auto bucket creation option

### DIFF
--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -36,6 +36,7 @@ type fakeS3Flags struct {
 	noIntegrity   bool
 	hostBucket    bool
 	autoBucket    bool
+	quiet         bool
 
 	boltDb         string
 	directFsPath   string
@@ -55,6 +56,9 @@ func (f *fakeS3Flags) attach(flagSet *flag.FlagSet) {
 	flagSet.BoolVar(&f.noIntegrity, "no-integrity", false, "Pass this flag to disable Content-MD5 validation when uploading.")
 	flagSet.BoolVar(&f.hostBucket, "hostbucket", false, "If passed, the bucket name will be extracted from the first segment of the hostname, rather than the first part of the URL path.")
 	flagSet.BoolVar(&f.autoBucket, "autobucket", false, "If passed, nonexistent buckets will be created on first use instead of raising an error")
+
+	// Logging
+	flagSet.BoolVar(&f.quiet, "quiet", false, "If passed, log messages are not printed to stderr")
 
 	// Backend specific:
 	flagSet.StringVar(&f.backendKind, "backend", "", "Backend to use to store data (memory, bolt, directfs, fs)")
@@ -220,11 +224,16 @@ func run() error {
 		log.Println("created -initialbucket", values.initialBucket)
 	}
 
+	logger := gofakes3.GlobalLog()
+	if values.quiet {
+		logger = gofakes3.DiscardLog()
+	}
+
 	faker := gofakes3.New(backend,
 		gofakes3.WithIntegrityCheck(!values.noIntegrity),
 		gofakes3.WithTimeSkewLimit(timeSkewLimit),
 		gofakes3.WithTimeSource(timeSource),
-		gofakes3.WithLogger(gofakes3.GlobalLog()),
+		gofakes3.WithLogger(logger),
 		gofakes3.WithHostBucket(values.hostBucket),
 		gofakes3.WithAutoBucket(values.autoBucket),
 	)

--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -35,6 +35,7 @@ type fakeS3Flags struct {
 	fixedTimeStr  string
 	noIntegrity   bool
 	hostBucket    bool
+	autoBucket    bool
 
 	boltDb         string
 	directFsPath   string
@@ -53,6 +54,7 @@ func (f *fakeS3Flags) attach(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&f.initialBucket, "initialbucket", "", "If passed, this bucket will be created on startup if it does not already exist.")
 	flagSet.BoolVar(&f.noIntegrity, "no-integrity", false, "Pass this flag to disable Content-MD5 validation when uploading.")
 	flagSet.BoolVar(&f.hostBucket, "hostbucket", false, "If passed, the bucket name will be extracted from the first segment of the hostname, rather than the first part of the URL path.")
+	flagSet.BoolVar(&f.autoBucket, "autobucket", false, "If passed, nonexistent buckets will be created on first use instead of raising an error")
 
 	// Backend specific:
 	flagSet.StringVar(&f.backendKind, "backend", "", "Backend to use to store data (memory, bolt, directfs, fs)")
@@ -180,6 +182,9 @@ func run() error {
 		if values.initialBucket != "" {
 			return fmt.Errorf("gofakes3: -initialbucket not supported by directfs")
 		}
+		if values.autoBucket {
+			return fmt.Errorf("gofakes3: -autobucket not supported by directfs")
+		}
 		if timeSource != nil {
 			log.Println("warning: time source not supported by this backend")
 		}
@@ -221,6 +226,7 @@ func run() error {
 		gofakes3.WithTimeSource(timeSource),
 		gofakes3.WithLogger(gofakes3.GlobalLog()),
 		gofakes3.WithHostBucket(values.hostBucket),
+		gofakes3.WithAutoBucket(values.autoBucket),
 	)
 
 	return listenAndServe(values.host, faker.Server())

--- a/error.go
+++ b/error.go
@@ -342,7 +342,7 @@ func requestTimeTooSkewed(at time.Time, max time.Duration) error {
 	}
 }
 
-// durationAsMilliseconds tricks xml.Marsha into serialising a time.Duration as
+// durationAsMilliseconds tricks xml.Marshal into serialising a time.Duration as
 // truncated milliseconds instead of nanoseconds.
 type durationAsMilliseconds time.Duration
 

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -645,7 +645,7 @@ func (g *GoFakeS3) copyObject(bucket, object string, meta map[string]string, w h
 	}
 
 	source := meta["X-Amz-Copy-Source"]
-	g.log.Print(LogInfo, "COPY:", source)
+	g.log.Print(LogInfo, "COPY:", source, "TO", bucket, object)
 
 	if len(object) > KeySizeLimit {
 		return ResourceError(ErrKeyTooLong, object)

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
@@ -1089,13 +1088,6 @@ func TestListBucketPagesFallback(t *testing.T) {
 			t.Fatal()
 		}
 	})
-}
-
-func s3HasErrorCode(err error, code gofakes3.ErrorCode) bool {
-	if err, ok := err.(awserr.Error); ok {
-		return code == gofakes3.ErrorCode(err.Code())
-	}
-	return false
 }
 
 func tryDumpResponse(rs *http.Response, body bool) string {

--- a/init_test.go
+++ b/init_test.go
@@ -812,6 +812,13 @@ func hasErrorCode(err error, code gofakes3.ErrorCode) bool {
 	}
 }
 
+func s3HasErrorCode(err error, code gofakes3.ErrorCode) bool {
+	if err, ok := err.(awserr.Error); ok {
+		return code == gofakes3.ErrorCode(err.Code())
+	}
+	return false
+}
+
 func httpClient() *http.Client {
 	return &http.Client{
 		Timeout: 2 * time.Second,

--- a/internal/s3assumer/.gitignore
+++ b/internal/s3assumer/.gitignore
@@ -1,0 +1,1 @@
+/s3assumer

--- a/internal/s3assumer/s300006_get_bucket_location_no_such_bucket.go
+++ b/internal/s3assumer/s300006_get_bucket_location_no_such_bucket.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/rand"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// Does GetBucketLocation return ErrNoSuchBucket when a nonexistent bucket is used?
+type S300006GetBucketLocationNoSuchBucket struct{}
+
+func (s S300006GetBucketLocationNoSuchBucket) Run(ctx *Context) error {
+	client := ctx.S3Client()
+
+	var b [40]byte
+	rand.Read(b[:])
+	bucket := hex.EncodeToString(b[:])
+
+	{ // Sanity check version length
+		rs, err := client.GetBucketLocation(&s3.GetBucketLocationInput{
+			Bucket: aws.String(bucket),
+		})
+		_ = rs
+		if aerr := (awserr.Error)(nil); errors.As(err, &aerr) {
+			if aerr.Code() != s3.ErrCodeNoSuchBucket {
+				return fmt.Errorf("expected NoSuchBucket, found %s", aerr.Code())
+			}
+		} else if err != nil {
+			return err
+		} else {
+			return fmt.Errorf("expected NoSuchBucket, but call succeeded: %+v", rs)
+		}
+	}
+
+	return nil
+}

--- a/internal/s3assumer/s300007_get_bucket_versioning_no_such_bucket.go
+++ b/internal/s3assumer/s300007_get_bucket_versioning_no_such_bucket.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/rand"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// Does GetBucketVersioning return ErrNoSuchBucket when a nonexistent bucket is used?
+// Does PutBucketVersioning return ErrNoSuchBucket when a nonexistent bucket is used?
+type S300007BucketVersioningNoSuchBucket struct{}
+
+func (s S300007BucketVersioningNoSuchBucket) Run(ctx *Context) error {
+	client := ctx.S3Client()
+
+	var b [40]byte
+	rand.Read(b[:])
+	bucket := hex.EncodeToString(b[:])
+
+	{ // GetBucketVersioning
+		rs, err := client.GetBucketVersioning(&s3.GetBucketVersioningInput{
+			Bucket: aws.String(bucket),
+		})
+		_ = rs
+		if aerr := (awserr.Error)(nil); errors.As(err, &aerr) {
+			if aerr.Code() != s3.ErrCodeNoSuchBucket {
+				return fmt.Errorf("expected NoSuchBucket, found %s", aerr.Code())
+			}
+		} else if err != nil {
+			return err
+		} else {
+			return fmt.Errorf("expected NoSuchBucket, but call succeeded: %+v", rs)
+		}
+	}
+
+	{ // PutBucketVersioning
+		rs, err := client.PutBucketVersioning(&s3.PutBucketVersioningInput{
+			Bucket: aws.String("gofakes3.shabbyrobe.org"),
+			VersioningConfiguration: &s3.VersioningConfiguration{
+				Status: aws.String("enorbled"),
+			},
+		})
+		_ = rs
+		if aerr := (awserr.Error)(nil); errors.As(err, &aerr) {
+			if aerr.Code() != s3.ErrCodeNoSuchBucket {
+				return fmt.Errorf("expected NoSuchBucket, found %s", aerr.Code())
+			}
+		} else if err != nil {
+			return err
+		} else {
+			return fmt.Errorf("expected NoSuchBucket, but call succeeded: %+v", rs)
+		}
+	}
+
+	return nil
+}

--- a/internal/s3assumer/tests.go
+++ b/internal/s3assumer/tests.go
@@ -6,4 +6,6 @@ var tests = []Test{
 	&S300003DeleteVersionFromNonexistentObject{},
 	&S300004ListVersionsWithVersionMarkerButNoKeyMarker{},
 	&S300005ListVersionsWithNeverVersionedBucket{},
+	&S300006GetBucketLocationNoSuchBucket{},
+	&S300007BucketVersioningNoSuchBucket{},
 }

--- a/log.go
+++ b/log.go
@@ -109,3 +109,17 @@ func (s *stdLog) Print(level LogLevel, v ...interface{}) {
 type discardLog struct{}
 
 func (d discardLog) Print(level LogLevel, v ...interface{}) {}
+
+func MultiLog(loggers ...Logger) Logger {
+	return &multiLog{loggers}
+}
+
+type multiLog struct {
+	loggers []Logger
+}
+
+func (m multiLog) Print(level LogLevel, v ...interface{}) {
+	for _, l := range m.loggers {
+		l.Print(level, v...)
+	}
+}

--- a/option.go
+++ b/option.go
@@ -80,3 +80,9 @@ func WithoutVersioning() Option {
 func WithUnimplementedPageError() Option {
 	return func(g *GoFakeS3) { g.failOnUnimplementedPage = true }
 }
+
+// WithAutoBucket instructs GoFakeS3 to create buckets that don't exist on first use,
+// rather than returning ErrNoSuchBucket.
+func WithAutoBucket(enabled bool) Option {
+	return func(g *GoFakeS3) { g.autoBucket = true }
+}

--- a/option_autobucket_test.go
+++ b/option_autobucket_test.go
@@ -73,7 +73,6 @@ func TestAutoBucketGetBucketLocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	autoSrv.assertObject(autoBucket, "object", nil, "hello")
 }
 
 func TestAutoBucketDeleteObjectVersion(t *testing.T) {

--- a/option_autobucket_test.go
+++ b/option_autobucket_test.go
@@ -62,6 +62,20 @@ func TestAutoBucketDeleteObject(t *testing.T) {
 	}
 }
 
+func TestAutoBucketGetBucketLocation(t *testing.T) {
+	autoSrv := newAutoBucketTestServer(t)
+	defer autoSrv.Close()
+	svc := autoSrv.s3Client()
+
+	_, err := svc.GetBucketLocation(&s3.GetBucketLocationInput{
+		Bucket: aws.String(autoBucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	autoSrv.assertObject(autoBucket, "object", nil, "hello")
+}
+
 func TestAutoBucketDeleteObjectVersion(t *testing.T) {
 	ts := newAutoBucketTestServer(t)
 	defer ts.Close()

--- a/option_autobucket_test.go
+++ b/option_autobucket_test.go
@@ -1,0 +1,123 @@
+package gofakes3_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/johannesboyne/gofakes3"
+)
+
+const autoBucket = "autobucket"
+
+func newAutoBucketTestServer(t *testing.T) *testServer {
+	t.Helper()
+	return newTestServer(t,
+		withoutInitialBuckets(),
+		withFakerOptions(gofakes3.WithAutoBucket(true)))
+}
+
+func TestAutoBucketPutObject(t *testing.T) {
+	autoSrv := newAutoBucketTestServer(t)
+	defer autoSrv.Close()
+	svc := autoSrv.s3Client()
+
+	_, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(autoBucket),
+		Key:    aws.String("object"),
+		Body:   bytes.NewReader([]byte("hello")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	autoSrv.assertObject(autoBucket, "object", nil, "hello")
+}
+
+func TestAutoBucketGetObject(t *testing.T) {
+	ts := newAutoBucketTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(autoBucket),
+		Key:    aws.String("object"),
+	})
+	if !hasErrorCode(err, gofakes3.ErrNoSuchKey) {
+		t.Fatal(err)
+	}
+}
+
+func TestAutoBucketDeleteObject(t *testing.T) {
+	ts := newAutoBucketTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(autoBucket),
+		Key:    aws.String("object"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAutoBucketDeleteObjectVersion(t *testing.T) {
+	ts := newAutoBucketTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket:    aws.String(autoBucket),
+		Key:       aws.String("object"),
+		VersionId: aws.String("version"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAutoBucketDeleteObjectsVersion(t *testing.T) {
+	ts := newAutoBucketTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.DeleteObjects(&s3.DeleteObjectsInput{
+		Delete: &s3.Delete{
+			Objects: []*s3.ObjectIdentifier{
+				{Key: aws.String("object1"), VersionId: aws.String("version1")},
+				{Key: aws.String("object2"), VersionId: aws.String("version2")},
+			},
+		},
+		Bucket: aws.String(autoBucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAutoBucketListMultipartUploads(t *testing.T) {
+	ts := newAutoBucketTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.ListMultipartUploads(&s3.ListMultipartUploadsInput{
+		Bucket: aws.String(autoBucket),
+	})
+	if !hasErrorCode(err, gofakes3.ErrNoSuchUpload) {
+		t.Fatal(err)
+	}
+}
+
+func TestAutoBucketGetBucketVersioning(t *testing.T) {
+	ts := newAutoBucketTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.GetBucketVersioning(&s3.GetBucketVersioningInput{
+		Bucket: aws.String(autoBucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This adds a new option to gofakes3: `WithAutoBucket`, which is off by default. The idea is that instead of failing when a bucket doesn't exist, it gets automatically created before first use. The use case I have is supplying a fake s3 instance as part of a wider suite of development helpers for an environment with a lot of services that expect the existence of lots of buckets. Being able to just presume any bucket we try to use is valid saves a fairly substantial setup step. I have a couple of other minor changes that relate to this workflow, with a view to supplying a more useful Dockerfile in a later PR than the one I chucked in there a few years ago.

I've added the "ensure bucket" check to each operation that needs to trigger the autobucket logic, but it raises another interesting conundrum: we don't really try to emulate any of the atomicity guarantees that S3 has. This change potentially makes that problem worse by expanding the surface of TOCTOU that we have (I haven't thought this through fully yet, just calling out that it's on my mind), but I think some sort of opt-in atomicity support might be something I could try to tackle later?