### PR TITLE
Investigate and fix issue 64

### DIFF
--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -380,6 +380,11 @@ func (db *MultiBucketBackend) PutObject(
 	input io.Reader, size int64,
 ) (result gofakes3.PutObjectResult, err error) {
 
+	err = gofakes3.MergeMetadata(db, bucketName, objectName, meta)
+	if err != nil {
+		return result, err
+	}
+
 	db.lock.Lock()
 	defer db.lock.Unlock()
 

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -295,6 +295,11 @@ func (db *SingleBucketBackend) PutObject(
 		return result, gofakes3.BucketNotFound(bucketName)
 	}
 
+	err = gofakes3.MergeMetadata(db, bucketName, objectName, meta)
+	if err != nil {
+		return result, err
+	}
+
 	db.lock.Lock()
 	defer db.lock.Unlock()
 

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -302,6 +302,11 @@ func (db *Backend) PutObject(
 		return result, err
 	}
 
+	err = gofakes3.MergeMetadata(db, bucketName, objectName, meta)
+	if err != nil {
+		return result, err
+	}
+
 	mod := db.timeSource.Now()
 	hash := md5.Sum(bts)
 

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -225,6 +225,11 @@ func (db *Backend) PutObject(bucketName, objectName string, meta map[string]stri
 		return result, err
 	}
 
+	err = gofakes3.MergeMetadata(db, bucketName, objectName, meta)
+	if err != nil {
+		return result, err
+	}
+
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
@@ -243,6 +248,7 @@ func (db *Backend) PutObject(bucketName, objectName string, meta map[string]stri
 		metadata:     meta,
 		lastModified: db.timeSource.Now(),
 	}
+
 	bucket.put(objectName, item)
 
 	if bucket.versioning == gofakes3.VersioningEnabled {

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -305,8 +305,11 @@ func TestCreateObjectMetadataAndObjectTagging(t *testing.T) {
 	})
 	ts.OK(err)
 
-	if *head.Metadata["Test"] != "test" {
+	if head.Metadata["Test"] == nil {
 		t.Fatalf("missing metadata: %+v", head.Metadata)
+	}
+	if *head.Metadata["Test"] != "test" {
+		t.Fatal("wrong metadata key")
 	}
 
 	_, err = svc.PutObjectTagging(&s3.PutObjectTaggingInput{
@@ -320,8 +323,17 @@ func TestCreateObjectMetadataAndObjectTagging(t *testing.T) {
 	})
 	ts.OK(err)
 
+	head, err = svc.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(defaultBucket),
+		Key:    aws.String("object"),
+	})
+	ts.OK(err)
+
+	if head.Metadata["Test"] == nil {
+		t.Fatalf("missing metadata after PutObjectTagging: %+v", head.Metadata)
+	}
 	if *head.Metadata["Test"] != "test" {
-		t.Fatalf("missing metadata: %+v", head.Metadata)
+		t.Fatal("wrong metadata key")
 	}
 
 	result, err := svc.GetObjectTagging(&s3.GetObjectTaggingInput{


### PR DESCRIPTION
Issue #64 [PutObjectTagging overwrites metadata](https://github.com/johannesboyne/gofakes3/issues/64#) showed that metadata is not carried over correctly.

This fixes the open issue by checking if the object exists before and merging the metadata fields.