### PR TITLE
add multi delete for versioned buckets, omit delete markers on list operation

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -130,7 +130,6 @@ type PutObjectResult struct {
 //
 // The Backend API is not yet stable; if you create your own Backend, breakage
 // is likely until this notice is removed.
-//
 type Backend interface {
 	// ListBuckets returns a list of all buckets owned by the authenticated
 	// sender of the request.
@@ -239,7 +238,6 @@ type Backend interface {
 // If you don't implement VersionedBackend, requests to GoFakeS3 that attempt to
 // make use of versions will return ErrNotImplemented if GoFakesS3 is unable to
 // find another way to satisfy the request.
-//
 type VersionedBackend interface {
 	// VersioningConfiguration must return a gofakes3.ErrNoSuchBucket error if the bucket
 	// does not exist. See gofakes3.BucketNotFound() for a convenient way to create one.
@@ -293,6 +291,9 @@ type VersionedBackend interface {
 	// the version does not exist (S300002), you MUST return an empty
 	// ObjectDeleteResult and a nil error.
 	DeleteObjectVersion(bucketName, objectName string, versionID VersionID) (ObjectDeleteResult, error)
+
+	// DeleteMultiVersions permanently deletes all of the specified Object Versions
+	DeleteMultiVersions(bucketName string, objects ...ObjectID) (MultiDeleteResult, error)
 
 	// Backend implementers can assume the ListBucketVersionsPage is valid:
 	// KeyMarker and VersionIDMarker will either both be set, or both be unset. No

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -104,7 +104,8 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 
 		if !prefix.Match(item.data.name, &match) {
 			continue
-
+		} else if item.data.deleteMarker {
+			continue
 		} else if match.CommonPrefix {
 			if match.MatchedPart == lastMatchedPart {
 				continue // Should not count towards keys
@@ -304,6 +305,43 @@ func (db *Backend) DeleteMulti(bucketName string, objects ...string) (result gof
 	return result, nil
 }
 
+func (db *Backend) DeleteMultiVersions(bucketName string, objects ...gofakes3.ObjectID) (result gofakes3.MultiDeleteResult, err error) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	bucket := db.buckets[bucketName]
+	if bucket == nil {
+		return result, gofakes3.BucketNotFound(bucketName)
+	}
+
+	now := db.timeSource.Now()
+
+	for _, object := range objects {
+		var dresult gofakes3.ObjectDeleteResult
+		var err error
+		if object.VersionID != "" {
+			_, err = bucket.rmVersion(object.Key, gofakes3.VersionID(object.VersionID), now)
+		} else {
+			dresult, err = bucket.rm(object.Key, now)
+			_ = dresult // FIXME: what to do with rm result in multi delete?
+		}
+
+		if err != nil {
+			errres := gofakes3.ErrorResultFromError(err)
+			if errres.Code == gofakes3.ErrInternal {
+				// FIXME: log
+			}
+
+			result.Error = append(result.Error, errres)
+
+		} else {
+			result.Deleted = append(result.Deleted, object)
+		}
+	}
+
+	return result, nil
+}
+
 func (db *Backend) VersioningConfiguration(bucketName string) (versioning gofakes3.VersioningConfiguration, rerr error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
@@ -340,6 +378,9 @@ func (db *Backend) GetObjectVersion(
 	bucketName, objectName string,
 	versionID gofakes3.VersionID,
 	rangeRequest *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
+	if versionID == "" {
+		return db.GetObject(bucketName, objectName, rangeRequest)
+	}
 
 	db.lock.RLock()
 	defer db.lock.RUnlock()
@@ -358,6 +399,10 @@ func (db *Backend) GetObjectVersion(
 }
 
 func (db *Backend) HeadObjectVersion(bucketName, objectName string, versionID gofakes3.VersionID) (*gofakes3.Object, error) {
+	if versionID == "" {
+		return db.HeadObject(bucketName, objectName)
+	}
+
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 

--- a/backend/s3mem/bucket.go
+++ b/backend/s3mem/bucket.go
@@ -183,6 +183,13 @@ func (b *bucket) objectVersion(objectName string, versionID gofakes3.VersionID) 
 		return nil, gofakes3.KeyNotFound(objectName)
 	}
 
+	if versionID == "" {
+		if obj.data.deleteMarker {
+			return nil, gofakes3.KeyNotFound(objectName)
+		}
+		return obj.data, nil
+	}
+
 	if obj.data != nil && obj.data.versionID == versionID {
 		return obj.data, nil
 	}

--- a/internal/s3assumer/s300008_hide_delete_markers copy.go
+++ b/internal/s3assumer/s300008_hide_delete_markers copy.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type S300008HideDeleteMarkers struct{}
+
+func (s S300008HideDeleteMarkers) Run(ctx *Context) error {
+	client := ctx.S3Client()
+	config := ctx.Config()
+	bucket := aws.String(config.BucketStandard())
+
+	if err := ctx.EnsureVersioningEnabled(client, config.BucketStandard()); err != nil {
+		return err
+	}
+
+	prefix := ctx.RandString(10) + "/"
+	key1, key2 := prefix+ctx.RandString(20), prefix+ctx.RandString(20)
+	keys := []string{key1, key2}
+
+	versions := map[string][]string{}
+	for _, key := range keys {
+		for i := 0; i < 2; i++ {
+			body := ctx.RandBytes(32)
+			vrs, err := client.PutObject(&s3.PutObjectInput{
+				Key:    aws.String(key),
+				Bucket: bucket,
+				Body:   bytes.NewReader(body),
+			})
+			if err != nil {
+				return err
+			}
+			versions[key] = append(versions[key], aws.StringValue(vrs.VersionId))
+		}
+	}
+
+	// delete one of the objects
+	_, err := client.DeleteObjects(&s3.DeleteObjectsInput{
+		Bucket: bucket,
+		Delete: &s3.Delete{
+			Objects: []*s3.ObjectIdentifier{
+				{
+					Key: aws.String(keys[0]),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// make ordinary list request. It should return only the keys[1].
+	page1, err := client.ListObjects(&s3.ListObjectsInput{
+		Bucket: bucket,
+		Prefix: aws.String(prefix),
+	})
+	if err != nil {
+		return err
+	}
+
+	l := len(page1.Contents)
+	if l != 1 {
+		return fmt.Errorf("unexpected number of objects %d but expected %d", l, 1)
+	}
+
+	if aws.StringValue(page1.Contents[0].Key) != keys[1] {
+		return fmt.Errorf("unexpected key %q but expected %q", aws.StringValue(page1.Contents[0].Key), keys[1])
+	}
+
+	return nil
+}

--- a/internal/s3assumer/s300009_delete_multiple_versions_of_multiple_objects.go
+++ b/internal/s3assumer/s300009_delete_multiple_versions_of_multiple_objects.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type S300009DeleteMultipleVersionsOfMultipleObjects struct{}
+
+func (s S300009DeleteMultipleVersionsOfMultipleObjects) Run(ctx *Context) error {
+	client := ctx.S3Client()
+	config := ctx.Config()
+	bucket := aws.String(config.BucketStandard())
+
+	if err := ctx.EnsureVersioningEnabled(client, config.BucketStandard()); err != nil {
+		return err
+	}
+
+	prefix := ctx.RandString(10) + "/"
+	key1, key2 := prefix+ctx.RandString(20), prefix+ctx.RandString(20)
+	keys := []string{key1, key2}
+
+	versions := map[string][]string{}
+	for _, key := range keys {
+		for i := 0; i < 2; i++ {
+			body := ctx.RandBytes(32)
+			vrs, err := client.PutObject(&s3.PutObjectInput{
+				Key:    aws.String(key),
+				Bucket: bucket,
+				Body:   bytes.NewReader(body),
+			})
+			if err != nil {
+				return err
+			}
+			versions[key] = append(versions[key], aws.StringValue(vrs.VersionId))
+		}
+	}
+
+	objVrs := make([]*s3.ObjectIdentifier, 0, 4)
+	for _, key := range keys {
+		for _, vrs := range versions[key] {
+			objVrs = append(objVrs, &s3.ObjectIdentifier{Key: aws.String(key), VersionId: aws.String(vrs)})
+		}
+	}
+
+	{ // Sanity check version length
+		rs, err := client.ListObjectVersions(&s3.ListObjectVersionsInput{
+			Bucket: bucket,
+			Prefix: aws.String(prefix),
+		})
+		if err != nil {
+			return err
+		}
+
+		// We have uploaded two keys, two versions per key, total of 4
+		if len(rs.Versions) != 4 {
+			return fmt.Errorf("unexpected number of objects %d but expected %d", len(rs.Versions), 1)
+		}
+	}
+
+	res, err := client.DeleteObjects(&s3.DeleteObjectsInput{
+		Bucket: bucket,
+		Delete: &s3.Delete{
+			Objects: objVrs,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf(err.Error(), res)
+	}
+
+	{ // Sanity check version length
+		rs, err := client.ListObjectVersions(&s3.ListObjectVersionsInput{
+			Bucket: bucket,
+			Prefix: aws.String(prefix),
+		})
+		if err != nil {
+			return err
+		}
+
+		// We have deleted all of the objects so we don't expect any version
+		if len(rs.Versions) > 0 {
+			return fmt.Errorf("unexpected number of objects %d but expected %d:\n%s", len(rs.Versions), 0, rs)
+		}
+	}
+
+	return nil
+}

--- a/internal/s3assumer/tests.go
+++ b/internal/s3assumer/tests.go
@@ -8,4 +8,6 @@ var tests = []Test{
 	&S300005ListVersionsWithNeverVersionedBucket{},
 	&S300006GetBucketLocationNoSuchBucket{},
 	&S300007BucketVersioningNoSuchBucket{},
+	&S300008HideDeleteMarkers{},
+	&S300009DeleteMultipleVersionsOfMultipleObjects{},
 }


### PR DESCRIPTION
Ordinary multi delete couldn't be used to permanently delete multiple objects from a versioned bucket. The backend.DeleteMulti ignored the version IDs and requested delete without version IDs which resulted in adding "delete markers" instead of permanent deletion of the objects.

In a versioned bucket, ordinary list/head/get requests shouldn't return the "delete marker"s. Added conditions to eliminate "delete marker"s from response.