### PR TITLE
Fix auto bucket creation option

### DIFF
--- a/option.go
+++ b/option.go
@@ -84,5 +84,5 @@ func WithUnimplementedPageError() Option {
 // WithAutoBucket instructs GoFakeS3 to create buckets that don't exist on first use,
 // rather than returning ErrNoSuchBucket.
 func WithAutoBucket(enabled bool) Option {
-	return func(g *GoFakeS3) { g.autoBucket = true }
+	return func(g *GoFakeS3) { g.autoBucket = enabled }
 }


### PR DESCRIPTION
Modify `WithAutoBucket` method to respect the `enabled` argument.

Previously, calling the method would cause buckets to always be automatically created, regardless of the provided argument.