### PR TITLE
Add Content-Encoding to metadata headers

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -11,6 +11,7 @@ var (
 		"Accept-Encoding",
 		"Authorization",
 		"Content-Disposition",
+		"Content-Encoding",
 		"Content-Length",
 		"Content-Type",
 		"X-Amz-Date",

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -1076,7 +1076,10 @@ func metadataSize(meta map[string]string) int {
 func metadataHeaders(headers map[string][]string, at time.Time, sizeLimit int) (map[string]string, error) {
 	meta := make(map[string]string)
 	for hk, hv := range headers {
-		if strings.HasPrefix(hk, "X-Amz-") || hk == "Content-Type" || hk == "Content-Disposition" {
+		if strings.HasPrefix(hk, "X-Amz-") ||
+			hk == "Content-Type" ||
+			hk == "Content-Disposition" ||
+			hk == "Content-Encoding" {
 			meta[hk] = hv[0]
 		}
 	}


### PR DESCRIPTION
gofakes3 was not preserving the Content-Encoding header, meaning that clients would get raw gzipped data in GetObject responses instead of the expected decompressed data when it was stored with `Content-Encoding: gzip`. With this change, it matches the behavior of S3 itself.