### PR TITLE
Add If-Modified-Since support

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -461,6 +461,12 @@ func (g *GoFakeS3) writeGetOrHeadObjectResponse(obj *Object, w http.ResponseWrit
 		return ErrNotModified
 	}
 
+	lastModified, _ := time.Parse(http.TimeFormat, obj.Metadata["Last-Modified"])
+	ifModifiedSince, _ := time.Parse(http.TimeFormat, r.Header.Get("If-Modified-Since"))
+	if !lastModified.IsZero() && !ifModifiedSince.Before(lastModified) {
+		return ErrNotModified
+	}
+
 	w.Header().Set("Accept-Ranges", "bytes")
 
 	return nil


### PR DESCRIPTION
The S3 API allows conditional caching by sending an `If-Modified-Since` header when retrieving an object (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax). If the timestamp provided in the `If-Modified-Since` header is not before the object modification timestamp, S3 API should respond with `304 Now Modified`. This PR implements this behavior.