### PR TITLE
Support for both path mode and host mode simultaneously

### DIFF
--- a/option.go
+++ b/option.go
@@ -19,7 +19,6 @@ func WithTimeSource(timeSource TimeSource) Option {
 // calculate the skew.
 //
 // See DefaultSkewLimit for the starting value, set to '0' to disable.
-//
 func WithTimeSkewLimit(skew time.Duration) Option {
 	return func(g *GoFakeS3) { g.timeSkew = skew }
 }
@@ -60,10 +59,26 @@ func WithRequestID(id uint64) Option {
 // If active, the URL 'http://mybucket.localhost/object' will be routed
 // as if the URL path was '/mybucket/object'.
 //
-// See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
-// for details.
+// This will apply to all requests. If you want to be more specific, provide
+// WithHostBucketBase.
+//
+// See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html for details.
 func WithHostBucket(enabled bool) Option {
 	return func(g *GoFakeS3) { g.hostBucket = enabled }
+}
+
+// WithHostBucketBase enables or disables bucket rewriting in the router, but only if the
+// host is a subdomain of the base.
+//
+// If set to 'example.com', the URL 'http://mybucket.example.com/object' will be routed as
+// if the URL path was '/mybucket/object', but 'http://example.com/bucket/object' will use
+// path-based bucket routing instead.
+//
+// You may pass multiple bases, they are tested in order.
+//
+// See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html for details.
+func WithHostBucketBase(hosts ...string) Option {
+	return func(g *GoFakeS3) { g.hostBucketBases = hosts }
 }
 
 // WithoutVersioning disables versioning on the passed backend, if it supported it.


### PR DESCRIPTION
Hallo Johannes! Hope you're well.

I've got a situation here at work where I need to support host based bucket routing as well as path-based at the same time. This PR adds a new middleware which, if enabled, takes precedence over the existing "all or nothing" middleware, that will support host-based bucket routing if and only if the host is a subdomain of the configured hosts.

If we start gofakes3 with the `example.com` host (and autobucket turned on just to make things easier):
```
go run ./cmd/gofakes3/ -backend=mem -autobucket -hostbucketbase=example.com
```

Requests for example.com will presume the first path segment is the bucket name:
```
$ curl -H "Host: example.com" http://localhost:9000/test
<?xml version="1.0" encoding="UTF-8"?>
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <Name>test</Name>
  <IsTruncated>false</IsTruncated>
  <Prefix></Prefix>
  <MaxKeys>1000</MaxKeys>
  <Marker></Marker>
</ListBucketResult>
```

Whereas requests for bucket.example.com will presume the first _host_ segment is the bucket name, and the entire path  becomes the object key:
```
$ curl -H "Host: bucket.example.com" http://localhost:9000/test
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>NoSuchKey</Code>
  <Resource>test</Resource>
</Error>
```