### PR TITLE
Add MultipartBackend interface to support overriding the multipart upload behaviour

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -317,7 +317,7 @@ type VersionedBackend interface {
 // gets finalised and pushed to the backend.
 type MultipartBackend interface {
 	CreateMultipartUpload(bucket, object string, meta map[string]string, initiated time.Time) (UploadID, error)
-	UploadPart(bucket, object string, id UploadID, partNumber int, at time.Time, body []byte) (etag string, err error)
+	UploadPart(bucket, object string, id UploadID, partNumber int, at time.Time, contentLength int64, input io.Reader) (etag string, err error)
 
 	ListMultipartUploads(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error)
 	ListParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error)

--- a/backend.go
+++ b/backend.go
@@ -2,6 +2,7 @@ package gofakes3
 
 import (
 	"io"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -307,6 +308,22 @@ type VersionedBackend interface {
 	// The Backend MUST treat a nil prefix identically to a zero prefix, and a
 	// nil page identically to a zero page.
 	ListBucketVersions(bucketName string, prefix *Prefix, page *ListBucketVersionsPage) (*ListBucketVersionsResult, error)
+}
+
+// MultipartBackend may be optionally implemented by a Backend in order to
+// support S3 multiplart uploads.
+// If you don't implement MultipartBackend, GoFakeS3 will fall back to an
+// in-memory implementation which holds all parts in memory until the upload
+// gets finalised and pushed to the backend.
+type MultipartBackend interface {
+	CreateMultipartUpload(bucket, object string, meta map[string]string, initiated time.Time) (UploadID, error)
+	UploadPart(bucket, object string, id UploadID, partNumber int, at time.Time, body []byte) (etag string, err error)
+
+	ListMultipartUploads(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error)
+	ListParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error)
+
+	AbortMultipartUpload(bucket, object string, id UploadID) error
+	CompleteMultipartUpload(bucket, object string, id UploadID, input *CompleteMultipartUploadRequest) (versionID VersionID, etag string, err error)
 }
 
 func MergeMetadata(db Backend, bucketName string, objectName string, meta map[string]string) error {

--- a/backend.go
+++ b/backend.go
@@ -2,7 +2,6 @@ package gofakes3
 
 import (
 	"io"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -316,8 +315,8 @@ type VersionedBackend interface {
 // in-memory implementation which holds all parts in memory until the upload
 // gets finalised and pushed to the backend.
 type MultipartBackend interface {
-	CreateMultipartUpload(bucket, object string, meta map[string]string, initiated time.Time) (UploadID, error)
-	UploadPart(bucket, object string, id UploadID, partNumber int, at time.Time, contentLength int64, input io.Reader) (etag string, err error)
+	CreateMultipartUpload(bucket, object string, meta map[string]string) (UploadID, error)
+	UploadPart(bucket, object string, id UploadID, partNumber int, contentLength int64, input io.Reader) (etag string, err error)
 
 	ListMultipartUploads(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error)
 	ListParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error)

--- a/backend/s3bolt/schema.go
+++ b/backend/s3bolt/schema.go
@@ -45,7 +45,7 @@ func (b *boltObject) Object(objectName string, rangeRequest *gofakes3.ObjectRang
 		Name:     objectName,
 		Metadata: b.Metadata,
 		Size:     b.Size,
-		Contents: s3io.ReaderWithDummyCloser{bytes.NewReader(data)},
+		Contents: s3io.ReaderWithDummyCloser{Reader: bytes.NewReader(data)},
 		Range:    rnge,
 		Hash:     b.Hash,
 	}, nil

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -1,7 +1,6 @@
 package gofakes3
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/xml"
@@ -36,7 +35,7 @@ type GoFakeS3 struct {
 	hostBucket              bool          // WithHostBucket
 	hostBucketBases         []string      // WithHostBucketBase
 	autoBucket              bool          // WithAutoBucket
-	uploader                *uploader
+	uploader                MultipartBackend
 	log                     Logger
 }
 
@@ -49,12 +48,18 @@ func New(backend Backend, options ...Option) *GoFakeS3 {
 		timeSkew:          DefaultSkewLimit,
 		metadataSizeLimit: DefaultMetadataSizeLimit,
 		integrityCheck:    true,
-		uploader:          newUploader(),
+		uploader:          newUploader(backend),
 		requestID:         0,
 	}
 
 	// versioned MUST be set before options as one of the options disables it:
 	s3.versioned, _ = backend.(VersionedBackend)
+
+	if mpb, ok := backend.(MultipartBackend); ok {
+		s3.uploader = mpb
+	} else {
+		s3.uploader = newUploader(backend)
+	}
 
 	for _, opt := range options {
 		opt(s3)
@@ -855,9 +860,12 @@ func (g *GoFakeS3) initiateMultipartUpload(bucket, object string, w http.Respons
 		return err
 	}
 
-	upload := g.uploader.Begin(bucket, object, meta, g.timeSource.Now())
+	uploadID, err := g.uploader.CreateMultipartUpload(bucket, object, meta, g.timeSource.Now())
+	if err != nil {
+		return err
+	}
 	out := InitiateMultipartUpload{
-		UploadID: upload.ID,
+		UploadID: uploadID,
 		Bucket:   bucket,
 		Key:      object,
 	}
@@ -882,15 +890,6 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 	size, err := strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
 	if err != nil || size <= 0 {
 		return ErrMissingContentLength
-	}
-
-	upload, err := g.uploader.Get(bucket, object, uploadID)
-	if err != nil {
-		// FIXME: What happens with S3 when you abort a multipart upload while
-		// part uploads are still in progress? In this case, we will retain the
-		// reference to the part even though another request goroutine may
-		// delete it; it will be available for GC when this function finishes.
-		return err
 	}
 
 	defer r.Body.Close()
@@ -920,7 +919,7 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 		return ErrIncompleteBody
 	}
 
-	etag, err := upload.AddPart(int(partNumber), g.timeSource.Now(), body)
+	etag, err := g.uploader.UploadPart(bucket, object, uploadID, int(partNumber), g.timeSource.Now(), body)
 	if err != nil {
 		return err
 	}
@@ -931,7 +930,7 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 
 func (g *GoFakeS3) abortMultipartUpload(bucket, object string, uploadID UploadID, w http.ResponseWriter, r *http.Request) error {
 	g.log.Print(LogInfo, "abort multipart upload", bucket, object, uploadID)
-	if _, err := g.uploader.Complete(bucket, object, uploadID); err != nil {
+	if err := g.uploader.AbortMultipartUpload(bucket, object, uploadID); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -946,22 +945,13 @@ func (g *GoFakeS3) completeMultipartUpload(bucket, object string, uploadID Uploa
 		return err
 	}
 
-	upload, err := g.uploader.Complete(bucket, object, uploadID)
+	versionID, etag, err := g.uploader.CompleteMultipartUpload(bucket, object, uploadID, &in)
 	if err != nil {
 		return err
 	}
 
-	fileBody, etag, err := upload.Reassemble(&in)
-	if err != nil {
-		return err
-	}
-
-	result, err := g.storage.PutObject(bucket, object, upload.Meta, bytes.NewReader(fileBody), int64(len(fileBody)))
-	if err != nil {
-		return err
-	}
-	if result.VersionID != "" {
-		w.Header().Set("x-amz-version-id", string(result.VersionID))
+	if versionID != "" {
+		w.Header().Set("x-amz-version-id", string(versionID))
 	}
 
 	return g.xmlEncoder(w).Encode(&CompleteMultipartUploadResult{
@@ -988,7 +978,7 @@ func (g *GoFakeS3) listMultipartUploads(bucket string, w http.ResponseWriter, r 
 		maxUploads = DefaultMaxUploads
 	}
 
-	out, err := g.uploader.List(bucket, marker, prefix, maxUploads)
+	out, err := g.uploader.ListMultipartUploads(bucket, marker, prefix, maxUploads)
 	if err != nil {
 		return err
 	}

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -910,16 +910,7 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 		}
 	}
 
-	body, err := ReadAll(rdr, size)
-	if err != nil {
-		return err
-	}
-
-	if int64(len(body)) != r.ContentLength {
-		return ErrIncompleteBody
-	}
-
-	etag, err := g.uploader.UploadPart(bucket, object, uploadID, int(partNumber), g.timeSource.Now(), body)
+	etag, err := g.uploader.UploadPart(bucket, object, uploadID, int(partNumber), g.timeSource.Now(), r.ContentLength, rdr)
 	if err != nil {
 		return err
 	}

--- a/uploader.go
+++ b/uploader.go
@@ -450,6 +450,9 @@ func (u *uploader) CompleteMultipartUpload(bucket, object string, id UploadID, i
 	if err != nil {
 		return "", "", err
 	}
+
+	// if getUnlocked succeeded, so will this:
+	u.buckets[bucket].remove(id)
 	return result.VersionID, hash, nil
 }
 

--- a/uploader.go
+++ b/uploader.go
@@ -1,6 +1,7 @@
 package gofakes3
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
@@ -13,6 +14,8 @@ import (
 	"github.com/johannesboyne/gofakes3/internal/goskipiter"
 	"github.com/ryszard/goskiplist/skiplist"
 )
+
+var _ MultipartBackend = &uploader{}
 
 var add1 = new(big.Int).SetInt64(1)
 
@@ -146,8 +149,8 @@ func (bu *bucketUploads) remove(uploadID UploadID) {
 // good convenience for Backend implementers if their use case did not require
 // persistent multipart upload handling, or it could be satisfied by this
 // naive implementation.
-//
 type uploader struct {
+	storage Backend
 	// uploadIDs use a big.Int to allow unbounded IDs (not that you'd be
 	// expected to ever generate 4.2 billion of these but who are we to judge?)
 	uploadID *big.Int
@@ -156,14 +159,15 @@ type uploader struct {
 	mu      sync.Mutex
 }
 
-func newUploader() *uploader {
+func newUploader(b Backend) *uploader {
 	return &uploader{
 		buckets:  make(map[string]*bucketUploads),
+		storage:  b,
 		uploadID: new(big.Int),
 	}
 }
 
-func (u *uploader) Begin(bucket, object string, meta map[string]string, initiated time.Time) *multipartUpload {
+func (u *uploader) CreateMultipartUpload(bucket, object string, meta map[string]string, initiated time.Time) (UploadID, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
@@ -186,7 +190,7 @@ func (u *uploader) Begin(bucket, object string, meta map[string]string, initiate
 
 	bucketUploads.add(mpu)
 
-	return mpu
+	return mpu.ID, nil
 }
 
 func (u *uploader) ListParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error) {
@@ -232,7 +236,7 @@ func (u *uploader) ListParts(bucket, object string, uploadID UploadID, marker in
 	return &result, nil
 }
 
-func (u *uploader) List(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error) {
+func (u *uploader) ListMultipartUploads(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
@@ -345,24 +349,100 @@ done:
 	return &result, nil
 }
 
-func (u *uploader) Complete(bucket, object string, id UploadID) (*multipartUpload, error) {
+func (u *uploader) AbortMultipartUpload(bucket, object string, id UploadID) error {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	up, err := u.getUnlocked(bucket, object, id)
+	_, err := u.getUnlocked(bucket, object, id)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// if getUnlocked succeeded, so will this:
 	u.buckets[bucket].remove(id)
 
-	return up, nil
+	return nil
 }
 
-func (u *uploader) Get(bucket, object string, id UploadID) (mu *multipartUpload, err error) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	return u.getUnlocked(bucket, object, id)
+func (u *uploader) UploadPart(bucket, object string, id UploadID, partNumber int, at time.Time, body []byte) (etag string, err error) {
+	if partNumber > MaxUploadPartNumber {
+		return "", ErrInvalidPart
+	}
+	mpu, err := u.getUnlocked(bucket, object, id)
+	if err != nil {
+		return "", err
+	}
+
+	mpu.mu.Lock()
+	defer mpu.mu.Unlock()
+
+	// What the ETag actually is is not specified, so let's just invent any old thing
+	// from guaranteed unique input:
+	hash := md5.New()
+	hash.Write([]byte(body))
+	etag = fmt.Sprintf(`"%s"`, hex.EncodeToString(hash.Sum(nil)))
+
+	part := multipartUploadPart{
+		PartNumber:   partNumber,
+		Body:         body,
+		ETag:         etag,
+		LastModified: NewContentTime(at),
+	}
+	if partNumber >= len(mpu.parts) {
+		mpu.parts = append(mpu.parts, make([]*multipartUploadPart, partNumber-len(mpu.parts)+1)...)
+	}
+	mpu.parts[partNumber] = &part
+	return etag, nil
+}
+
+func (u *uploader) CompleteMultipartUpload(bucket, object string, id UploadID, input *CompleteMultipartUploadRequest) (version VersionID, etag string, err error) {
+	mpu, err := u.getUnlocked(bucket, object, id)
+	if err != nil {
+		return "", "", err
+	}
+
+	mpu.mu.Lock()
+	defer mpu.mu.Unlock()
+
+	mpuPartsLen := len(mpu.parts)
+
+	// FIXME: what does AWS do when mpu.Parts > input.Parts? Presumably you may
+	// end up uploading more parts than you need to assemble, so it should
+	// probably just ignore that?
+	if len(input.Parts) > mpuPartsLen {
+		return "", "", ErrInvalidPart
+	}
+
+	if !input.partsAreSorted() {
+		return "", "", ErrInvalidPartOrder
+	}
+
+	var size int64
+
+	for _, inPart := range input.Parts {
+		if inPart.PartNumber >= mpuPartsLen || mpu.parts[inPart.PartNumber] == nil {
+			return "", "", ErrorMessagef(ErrInvalidPart, "unexpected part number %d in complete request", inPart.PartNumber)
+		}
+
+		upPart := mpu.parts[inPart.PartNumber]
+		if strings.Trim(inPart.ETag, "\"") != strings.Trim(upPart.ETag, "\"") {
+			return "", "", ErrorMessagef(ErrInvalidPart, "unexpected part etag for number %d in complete request", inPart.PartNumber)
+		}
+
+		size += int64(len(upPart.Body))
+	}
+
+	body := make([]byte, 0, size)
+	for _, part := range input.Parts {
+		body = append(body, mpu.parts[part.PartNumber].Body...)
+	}
+
+	hash := fmt.Sprintf("%x", md5.Sum(body))
+
+	result, err := u.storage.PutObject(bucket, object, mpu.Meta, bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return "", "", err
+	}
+	return result.VersionID, hash, nil
 }
 
 func (u *uploader) getUnlocked(bucket, object string, id UploadID) (mu *multipartUpload, err error) {
@@ -446,73 +526,4 @@ type multipartUpload struct {
 	parts []*multipartUploadPart
 
 	mu sync.Mutex
-}
-
-func (mpu *multipartUpload) AddPart(partNumber int, at time.Time, body []byte) (etag string, err error) {
-	if partNumber > MaxUploadPartNumber {
-		return "", ErrInvalidPart
-	}
-
-	mpu.mu.Lock()
-	defer mpu.mu.Unlock()
-
-	// What the ETag actually is is not specified, so let's just invent any old thing
-	// from guaranteed unique input:
-	hash := md5.New()
-	hash.Write([]byte(body))
-	etag = fmt.Sprintf(`"%s"`, hex.EncodeToString(hash.Sum(nil)))
-
-	part := multipartUploadPart{
-		PartNumber:   partNumber,
-		Body:         body,
-		ETag:         etag,
-		LastModified: NewContentTime(at),
-	}
-	if partNumber >= len(mpu.parts) {
-		mpu.parts = append(mpu.parts, make([]*multipartUploadPart, partNumber-len(mpu.parts)+1)...)
-	}
-	mpu.parts[partNumber] = &part
-	return etag, nil
-}
-
-func (mpu *multipartUpload) Reassemble(input *CompleteMultipartUploadRequest) (body []byte, etag string, err error) {
-	mpu.mu.Lock()
-	defer mpu.mu.Unlock()
-
-	mpuPartsLen := len(mpu.parts)
-
-	// FIXME: what does AWS do when mpu.Parts > input.Parts? Presumably you may
-	// end up uploading more parts than you need to assemble, so it should
-	// probably just ignore that?
-	if len(input.Parts) > mpuPartsLen {
-		return nil, "", ErrInvalidPart
-	}
-
-	if !input.partsAreSorted() {
-		return nil, "", ErrInvalidPartOrder
-	}
-
-	var size int64
-
-	for _, inPart := range input.Parts {
-		if inPart.PartNumber >= mpuPartsLen || mpu.parts[inPart.PartNumber] == nil {
-			return nil, "", ErrorMessagef(ErrInvalidPart, "unexpected part number %d in complete request", inPart.PartNumber)
-		}
-
-		upPart := mpu.parts[inPart.PartNumber]
-		if strings.Trim(inPart.ETag, "\"") != strings.Trim(upPart.ETag, "\"") {
-			return nil, "", ErrorMessagef(ErrInvalidPart, "unexpected part etag for number %d in complete request", inPart.PartNumber)
-		}
-
-		size += int64(len(upPart.Body))
-	}
-
-	body = make([]byte, 0, size)
-	for _, part := range input.Parts {
-		body = append(body, mpu.parts[part.PartNumber].Body...)
-	}
-
-	hash := fmt.Sprintf("%x", md5.Sum(body))
-
-	return body, hash, nil
 }


### PR DESCRIPTION
This PR adds support for implementation the optional `MultipartBackend` interface to avoid the in-memory multipart uploader and instead use a custom one.

I have to admit I accidentally opened this PR and the Copy PR on this repo instead of our fork but I thought it might be a good addition anyway.