### PR TITLE
Extend Backend interface with CopyObject method

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -230,6 +230,8 @@ type Backend interface {
 	PutObject(bucketName, key string, meta map[string]string, input io.Reader, size int64) (PutObjectResult, error)
 
 	DeleteMulti(bucketName string, objects ...string) (MultiDeleteResult, error)
+
+	CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (CopyObjectResult, error)
 }
 
 // VersionedBackend may be optionally implemented by a Backend in order to support

--- a/backend.go
+++ b/backend.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/Mikubill/gofakes3"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
@@ -317,7 +316,7 @@ type VersionedBackend interface {
 // CopyObject is a helper function useful for quickly implementing CopyObject on
 // a backend that already supports GetObject and PutObject. This isn't very
 // efficient so only use this if performance isn't important.
-func CopyObject(db Backend, srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
+func CopyObject(db Backend, srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result CopyObjectResult, err error) {
 	c, err := db.GetObject(srcBucket, srcKey, nil)
 	if err != nil {
 		return
@@ -329,9 +328,9 @@ func CopyObject(db Backend, srcBucket, srcKey, dstBucket, dstKey string, meta ma
 		return
 	}
 
-	return gofakes3.CopyObjectResult{
+	return CopyObjectResult{
 		ETag:         `"` + hex.EncodeToString(c.Hash) + `"`,
-		LastModified: gofakes3.NewContentTime(time.Now()),
+		LastModified: NewContentTime(time.Now()),
 	}, nil
 }
 

--- a/backend/s3afero/multi.go
+++ b/backend/s3afero/multi.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/internal/s3io"
@@ -466,21 +465,7 @@ func (db *MultiBucketBackend) PutObject(
 }
 
 func (db *MultiBucketBackend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
-	c, err := db.GetObject(srcBucket, srcKey, nil)
-	if err != nil {
-		return
-	}
-	defer c.Contents.Close()
-
-	_, err = db.PutObject(dstBucket, dstKey, meta, c.Contents, c.Size)
-	if err != nil {
-		return
-	}
-
-	return gofakes3.CopyObjectResult{
-		ETag:         `"` + hex.EncodeToString(c.Hash) + `"`,
-		LastModified: gofakes3.NewContentTime(time.Now()),
-	}, nil
+	return gofakes3.CopyObject(db, srcBucket, srcKey, dstBucket, dstKey, meta)
 }
 
 func (db *MultiBucketBackend) DeleteObject(bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -420,21 +420,7 @@ func (db *SingleBucketBackend) DeleteMulti(bucketName string, objects ...string)
 }
 
 func (db *SingleBucketBackend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
-	c, err := db.GetObject(srcBucket, srcKey, nil)
-	if err != nil {
-		return
-	}
-	defer c.Contents.Close()
-
-	_, err = db.PutObject(dstBucket, dstKey, meta, c.Contents, c.Size)
-	if err != nil {
-		return
-	}
-
-	return gofakes3.CopyObjectResult{
-		ETag:         `"` + hex.EncodeToString(c.Hash) + `"`,
-		LastModified: gofakes3.NewContentTime(time.Now()),
-	}, nil
+	return gofakes3.CopyObject(db, srcBucket, srcKey, dstBucket, dstKey, meta)
 }
 
 func (db *SingleBucketBackend) DeleteObject(bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"time"
 
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/internal/s3io"
@@ -332,6 +333,24 @@ func (db *Backend) PutObject(
 		}
 		return nil
 	})
+}
+
+func (db *Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
+	c, err := db.GetObject(srcBucket, srcKey, nil)
+	if err != nil {
+		return
+	}
+	defer c.Contents.Close()
+
+	_, err = db.PutObject(dstBucket, dstKey, meta, c.Contents, c.Size)
+	if err != nil {
+		return
+	}
+
+	return gofakes3.CopyObjectResult{
+		ETag:         `"` + hex.EncodeToString(c.Hash) + `"`,
+		LastModified: gofakes3.NewContentTime(time.Now()),
+	}, nil
 }
 
 func (db *Backend) DeleteObject(bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {

--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"time"
 
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/internal/s3io"
@@ -336,21 +335,7 @@ func (db *Backend) PutObject(
 }
 
 func (db *Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
-	c, err := db.GetObject(srcBucket, srcKey, nil)
-	if err != nil {
-		return
-	}
-	defer c.Contents.Close()
-
-	_, err = db.PutObject(dstBucket, dstKey, meta, c.Contents, c.Size)
-	if err != nil {
-		return
-	}
-
-	return gofakes3.CopyObjectResult{
-		ETag:         `"` + hex.EncodeToString(c.Hash) + `"`,
-		LastModified: gofakes3.NewContentTime(time.Now()),
-	}, nil
+	return gofakes3.CopyObject(db, srcBucket, srcKey, dstBucket, dstKey, meta)
 }
 
 func (db *Backend) DeleteObject(bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"io"
 	"sync"
-	"time"
 
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/internal/goskipiter"
@@ -262,21 +261,7 @@ func (db *Backend) PutObject(bucketName, objectName string, meta map[string]stri
 }
 
 func (db *Backend) CopyObject(srcBucket, srcKey, dstBucket, dstKey string, meta map[string]string) (result gofakes3.CopyObjectResult, err error) {
-	c, err := db.GetObject(srcBucket, srcKey, nil)
-	if err != nil {
-		return
-	}
-	defer c.Contents.Close()
-
-	_, err = db.PutObject(dstBucket, dstKey, meta, c.Contents, c.Size)
-	if err != nil {
-		return
-	}
-
-	return gofakes3.CopyObjectResult{
-		ETag:         `"` + hex.EncodeToString(c.Hash) + `"`,
-		LastModified: gofakes3.NewContentTime(time.Now()),
-	}, nil
+	return gofakes3.CopyObject(db, srcBucket, srcKey, dstBucket, dstKey, meta)
 }
 
 func (db *Backend) DeleteObject(bucketName, objectName string) (result gofakes3.ObjectDeleteResult, rerr error) {


### PR DESCRIPTION
Drawing some inspiration from the https://github.com/Mikubill/gofakes3 fork used by `Rclone`, this PR adds Copy support to this fork to avoid downloading and re uploading an object on copy.