### PR TITLE
Data race: lock on abort/complete of multipart upload

### DIFF
--- a/uploader.go
+++ b/uploader.go
@@ -377,6 +377,8 @@ func (u *uploader) UploadPart(bucket, object string, id UploadID, partNumber int
 	if len(body) != int(contentLength) {
 		return "", ErrIncompleteBody
 	}
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	mpu, err := u.getUnlocked(bucket, object, id)
 	if err != nil {
 		return "", err
@@ -405,6 +407,9 @@ func (u *uploader) UploadPart(bucket, object string, id UploadID, partNumber int
 }
 
 func (u *uploader) CompleteMultipartUpload(bucket, object string, id UploadID, input *CompleteMultipartUploadRequest) (version VersionID, etag string, err error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
 	mpu, err := u.getUnlocked(bucket, object, id)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
Hi, Thanks for this great module! Ran into a data race while interacting concurrently with the multipart capabilities. It appears that the uploader lock is not consistently obtained when completing or aborting a multipart upload, which ends up racing on bucket access. This patch now obtains the lock for these two methods. Data race output below for reference:

<details>
<summary>Data race trace</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c003823a10 by goroutine 601:
  runtime.mapaccess1_faststr()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/runtime/map_faststr.go:13 +0x40c
  github.com/johannesboyne/gofakes3.(*uploader).getUnlocked()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/uploader.go:467 +0x124
  github.com/johannesboyne/gofakes3.(*uploader).UploadPart()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/uploader.go:380 +0xf4
  github.com/johannesboyne/gofakes3.(*GoFakeS3).putMultipartUploadPart()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/gofakes3.go:901 +0x5f0
  github.com/johannesboyne/gofakes3.(*GoFakeS3).routeMultipartUpload()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/routing.go:180 +0x108
  github.com/johannesboyne/gofakes3.(*GoFakeS3).routeBase()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/routing.go:43 +0x4cc
  github.com/johannesboyne/gofakes3.(*GoFakeS3).routeBase-fm()
      <autogenerated>:1 +0x4c
  net/http.HandlerFunc.ServeHTTP()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:2166 +0x48
  github.com/johannesboyne/gofakes3.(*withCORS).ServeHTTP()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/cors.go:46 +0x51c
  github.com/johannesboyne/gofakes3.(*GoFakeS3).Server.(*GoFakeS3).timeSkewMiddleware.func1()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/gofakes3.go:111 +0x18c
  net/http.HandlerFunc.ServeHTTP()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:2166 +0x48
  net/http.serverHandler.ServeHTTP()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:3137 +0x298
  net/http.(*conn).serve()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:2039 +0xf28
  net/http.(*Server).Serve.gowrap3()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:3285 +0x4c

Previous write at 0x00c003823a10 by goroutine 710:
  runtime.mapassign_faststr()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/runtime/map_faststr.go:203 +0x41c
  github.com/johannesboyne/gofakes3.(*bucketUploads).remove()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/uploader.go:103 +0x94
  github.com/johannesboyne/gofakes3.(*uploader).AbortMultipartUpload()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/uploader.go:364 +0x27c
  github.com/johannesboyne/gofakes3.(*GoFakeS3).abortMultipartUpload()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/gofakes3.go:912 +0x218
  github.com/johannesboyne/gofakes3.(*GoFakeS3).routeMultipartUpload()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/routing.go:182 +0x1e0
  github.com/johannesboyne/gofakes3.(*GoFakeS3).routeBase()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/routing.go:43 +0x4cc
  github.com/johannesboyne/gofakes3.(*GoFakeS3).routeBase-fm()
      <autogenerated>:1 +0x4c
  net/http.HandlerFunc.ServeHTTP()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:2166 +0x48
  github.com/johannesboyne/gofakes3.(*withCORS).ServeHTTP()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/cors.go:46 +0x51c
  github.com/johannesboyne/gofakes3.(*GoFakeS3).Server.(*GoFakeS3).timeSkewMiddleware.func1()
      ~/pkg/mod/github.com/johannesboyne/gofakes3@v0.0.0-20240217095638-c55a48f17be6/gofakes3.go:111 +0x18c
  net/http.HandlerFunc.ServeHTTP()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:2166 +0x48
  net/http.serverHandler.ServeHTTP()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:3137 +0x298
  net/http.(*conn).serve()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:2039 +0xf28
  net/http.(*Server).Serve.gowrap3()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:3285 +0x4c

Goroutine 601 (running) created at:
  net/http.(*Server).Serve()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:3285 +0x674
  net/http/httptest.(*Server).goServe.func1()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/httptest/server.go:310 +0xb0

Goroutine 710 (running) created at:
  net/http.(*Server).Serve()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/server.go:3285 +0x674
  net/http/httptest.(*Server).goServe.func1()
      ~/.gimme/versions/go1.22.1.darwin.arm64/src/net/http/httptest/server.go:310 +0xb0
==================
```

</details>