### PR TITLE
Fix timestamp formatting.

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -96,7 +96,7 @@ func NewContentTime(t time.Time) ContentTime {
 func (c ContentTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	// This is the format expected by the aws xml code, not the default.
 	if !c.IsZero() {
-		var s = c.Format("2006-01-02T15:04:05.999Z")
+		var s = c.UTC().Format("2006-01-02T15:04:05.999Z")
 		return e.EncodeElement(s, start)
 	}
 	return nil

--- a/messages_test.go
+++ b/messages_test.go
@@ -40,7 +40,7 @@ func TestContentTime(t *testing.T) {
 
 	var v = testMsg{
 		Foo:  "bar",
-		Time: NewContentTime(time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC)),
+		Time: NewContentTime(time.Date(2019, 1, 1, 7, 0, 0, 0, time.FixedZone("EST", -5*3600))), // 7am EST = 12pm UTC
 	}
 	out, err := xml.Marshal(&v)
 	if err != nil {


### PR DESCRIPTION
The format string used here outputs a local time with a literal "Z" indicating UTC.  This is correct only if the input time is [first converted to] UTC.