### PR TITLE
Add rudimentary Location return support for CompleteMultipartUpload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.44.256
+	github.com/cevatbarisyilmaz/ara v0.0.4
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46
 	github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500
 	github.com/spf13/afero v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go v1.44.256 h1:O8VH+bJqgLDguqkH/xQBFz5o/YheeZqgcOYIgsTVWY4=
 github.com/aws/aws-sdk-go v1.44.256/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/cevatbarisyilmaz/ara v0.0.4 h1:SGH10hXpBJhhTlObuZzTuFn1rrdmjQImITXnZVPSodc=
+github.com/cevatbarisyilmaz/ara v0.0.4/go.mod h1:BfFOxnUd6Mj6xmcvRxHN3Sr21Z1T3U2MYkYOmoQe4Ts=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -937,7 +937,13 @@ func (g *GoFakeS3) completeMultipartUpload(bucket, object string, uploadID Uploa
 	if r.TLS != nil {
 		protocol = "https"
 	}
-	location := fmt.Sprintf("%s://%s/%s", protocol, r.Host, object)
+
+	var location string
+	if g.hostBucket {
+		location = fmt.Sprintf("%s://%s/%s", protocol, r.Host, object)
+	} else {
+		location = fmt.Sprintf("%s://%s/%s/%s", protocol, r.Host, bucket, object)
+	}
 
 	return g.xmlEncoder(w).Encode(&CompleteMultipartUploadResult{
 		ETag:     etag,

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -933,10 +933,17 @@ func (g *GoFakeS3) completeMultipartUpload(bucket, object string, uploadID Uploa
 		w.Header().Set("x-amz-version-id", string(versionID))
 	}
 
+	protocol := "http"
+	if r.TLS != nil {
+		protocol = "https"
+	}
+	location := fmt.Sprintf("%s://%s/%s", protocol, r.Host, object)
+
 	return g.xmlEncoder(w).Encode(&CompleteMultipartUploadResult{
-		ETag:   etag,
-		Bucket: bucket,
-		Key:    object,
+		ETag:     etag,
+		Bucket:   bucket,
+		Key:      object,
+		Location: location,
 	})
 }
 

--- a/init_test.go
+++ b/init_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"github.com/cevatbarisyilmaz/ara"
 	"io"
 	"io/ioutil"
 	"log"
@@ -143,10 +144,11 @@ type testServer struct {
 	gofakes3.TimeSourceAdvancer
 	*gofakes3.GoFakeS3
 
-	backend   gofakes3.Backend
-	versioned gofakes3.VersionedBackend
-	server    *httptest.Server
-	options   []gofakes3.Option
+	backend       gofakes3.Backend
+	versioned     gofakes3.VersionedBackend
+	server        *httptest.Server
+	options       []gofakes3.Option
+	useHostBucket bool
 
 	// if this is nil, no buckets are created. by default, a starting bucket is
 	// created using the value of the 'defaultBucket' constant.
@@ -161,6 +163,12 @@ func withoutInitialBuckets() testServerOption {
 }
 func withInitialBuckets(buckets ...string) testServerOption {
 	return func(ts *testServer) { ts.initialBuckets = buckets }
+}
+func withHostBucket() testServerOption {
+	return func(ts *testServer) {
+		ts.options = append(ts.options, gofakes3.WithHostBucket(true))
+		ts.useHostBucket = true
+	}
 }
 func withVersioning() testServerOption {
 	return func(ts *testServer) { ts.versioning = true }
@@ -272,11 +280,13 @@ func (ts *testServer) backendGetString(bucket, key string, rnge *gofakes3.Object
 
 func (ts *testServer) s3Client() *s3.S3 {
 	ts.Helper()
+
 	config := aws.NewConfig()
 	config.WithEndpoint(ts.server.URL)
 	config.WithRegion("region")
+	config.WithHTTPClient(ara.NewClient(ara.NewCustomResolver(map[string][]string{fmt.Sprintf("%s.127.0.0.1", defaultBucket): {"127.0.0.1"}, "localhost": {"127.0.0.1"}})))
 	config.WithCredentials(credentials.NewStaticCredentials("dummy-access", "dummy-secret", ""))
-	config.WithS3ForcePathStyle(true) // Removes need for subdomain
+	config.WithS3ForcePathStyle(!ts.useHostBucket) // Removes need for subdomain
 	svc := s3.New(session.New(), config)
 	return svc
 }
@@ -371,7 +381,7 @@ func (ts *testServer) uploadPart(bucket, object string, uploadID string, num int
 	return &s3.CompletedPart{ETag: aws.String(*mpu.ETag), PartNumber: aws.Int64(num)}
 }
 
-func (ts *testServer) assertCompleteUpload(bucket, object, uploadID string, parts []*s3.CompletedPart, body interface{}) {
+func (ts *testServer) assertCompleteUpload(bucket, object, uploadID string, parts []*s3.CompletedPart, body interface{}, hostBucket bool) {
 	ts.Helper()
 
 	svc := ts.s3Client()
@@ -389,8 +399,18 @@ func (ts *testServer) assertCompleteUpload(bucket, object, uploadID string, part
 		ts.Fatal("missing location")
 	}
 
-	if *mpu.Location != fmt.Sprintf("%s/%s", ts.server.URL, object) {
-		ts.Fatal("unexpected location:", *mpu.Location)
+	// split into protocol, host, port
+	u, err := url.Parse(ts.server.URL)
+	ts.OK(err)
+
+	if hostBucket {
+		if *mpu.Location != fmt.Sprintf("%s://%s.%s/%s", u.Scheme, bucket, u.Host, object) {
+			ts.Fatal("unexpected location:", *mpu.Location)
+		}
+	} else {
+		if *mpu.Location != fmt.Sprintf("%s/%s/%s", ts.server.URL, bucket, object) {
+			ts.Fatal("unexpected location:", *mpu.Location)
+		}
 	}
 
 	_ = mpu // FIXME: assert some of this

--- a/init_test.go
+++ b/init_test.go
@@ -286,7 +286,7 @@ func (ts *testServer) s3Client() *s3.S3 {
 	config.WithRegion("region")
 	config.WithHTTPClient(ara.NewClient(ara.NewCustomResolver(map[string][]string{fmt.Sprintf("%s.127.0.0.1", defaultBucket): {"127.0.0.1"}, "localhost": {"127.0.0.1"}})))
 	config.WithCredentials(credentials.NewStaticCredentials("dummy-access", "dummy-secret", ""))
-	config.WithS3ForcePathStyle(!ts.useHostBucket) // Removes need for subdomain
+	config.WithS3ForcePathStyle(!ts.useHostBucket)
 	svc := s3.New(session.New(), config)
 	return svc
 }
@@ -381,7 +381,7 @@ func (ts *testServer) uploadPart(bucket, object string, uploadID string, num int
 	return &s3.CompletedPart{ETag: aws.String(*mpu.ETag), PartNumber: aws.Int64(num)}
 }
 
-func (ts *testServer) assertCompleteUpload(bucket, object, uploadID string, parts []*s3.CompletedPart, body interface{}, hostBucket bool) {
+func (ts *testServer) assertCompleteUpload(bucket, object, uploadID string, parts []*s3.CompletedPart, body interface{}) {
 	ts.Helper()
 
 	svc := ts.s3Client()
@@ -403,7 +403,7 @@ func (ts *testServer) assertCompleteUpload(bucket, object, uploadID string, part
 	u, err := url.Parse(ts.server.URL)
 	ts.OK(err)
 
-	if hostBucket {
+	if ts.useHostBucket {
 		if *mpu.Location != fmt.Sprintf("%s://%s.%s/%s", u.Scheme, bucket, u.Host, object) {
 			ts.Fatal("unexpected location:", *mpu.Location)
 		}

--- a/init_test.go
+++ b/init_test.go
@@ -384,6 +384,15 @@ func (ts *testServer) assertCompleteUpload(bucket, object, uploadID string, part
 		},
 	})
 	ts.OK(err)
+
+	if mpu.Location == nil {
+		ts.Fatal("missing location")
+	}
+
+	if *mpu.Location != fmt.Sprintf("%s/%s", ts.server.URL, object) {
+		ts.Fatal("unexpected location:", *mpu.Location)
+	}
+
 	_ = mpu // FIXME: assert some of this
 
 	ts.assertObject(bucket, object, nil, body)

--- a/uploader_test.go
+++ b/uploader_test.go
@@ -139,22 +139,42 @@ func TestListMultipartUploadsPrefix(t *testing.T) {
 }
 
 func TestListMultipartUploadParts(t *testing.T) {
-	ts := newTestServer(t)
-	defer ts.Close()
+	doUpload := func(ts *testServer) (string, []*s3.CompletedPart) {
+		id := ts.createMultipartUpload(defaultBucket, "foo", nil)
 
-	id := ts.createMultipartUpload(defaultBucket, "foo", nil)
+		parts := []*s3.CompletedPart{
+			ts.uploadPart(defaultBucket, "foo", id, 1, []byte("abc")),
+			ts.uploadPart(defaultBucket, "foo", id, 2, []byte("def")),
+			ts.uploadPart(defaultBucket, "foo", id, 3, []byte("ghi")),
+		}
 
-	parts := []*s3.CompletedPart{
-		ts.uploadPart(defaultBucket, "foo", id, 1, []byte("abc")),
-		ts.uploadPart(defaultBucket, "foo", id, 2, []byte("def")),
-		ts.uploadPart(defaultBucket, "foo", id, 3, []byte("ghi")),
+		ts.assertListUploadParts(defaultBucket, "foo", id,
+			listUploadPartsOpts{}.withCompletedParts(parts...))
+
+		return id, parts
 	}
 
-	ts.assertListUploadParts(defaultBucket, "foo", id,
-		listUploadPartsOpts{}.withCompletedParts(parts...))
+	t.Run("location: HostBucket", func(t *testing.T) {
+		ts := newTestServer(t, withHostBucket())
+		defer ts.Close()
 
-	ts.assertCompleteUpload(defaultBucket, "foo", id, parts, []byte("abcdefghi"))
+		id, parts := doUpload(ts)
 
-	// No parts should be returned after the upload is completed:
-	ts.assertListUploadPartsFails(gofakes3.ErrNoSuchUpload, defaultBucket, "foo", id, listUploadPartsOpts{})
+		ts.assertCompleteUpload(defaultBucket, "foo", id, parts, []byte("abcdefghi"), true)
+
+		// No parts should be returned after the upload is completed:
+		ts.assertListUploadPartsFails(gofakes3.ErrNoSuchUpload, defaultBucket, "foo", id, listUploadPartsOpts{})
+	})
+
+	t.Run("location: PathBucket", func(t *testing.T) {
+		ts := newTestServer(t)
+		defer ts.Close()
+
+		id, parts := doUpload(ts)
+
+		ts.assertCompleteUpload(defaultBucket, "foo", id, parts, []byte("abcdefghi"), false)
+
+		// No parts should be returned after the upload is completed:
+		ts.assertListUploadPartsFails(gofakes3.ErrNoSuchUpload, defaultBucket, "foo", id, listUploadPartsOpts{})
+	})
 }


### PR DESCRIPTION
Based on AWS documentation: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html

A location URL should be returned for the newly created object. This implementation adds this field to the output.

Both PathBucket and HostBucket are supported.