### PR TITLE
Fix multipart upload api mismatch with aws s3 api

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -852,7 +852,7 @@ func (g *GoFakeS3) initiateMultipartUpload(bucket, object string, w http.Respons
 	if err != nil {
 		return err
 	}
-	out := InitiateMultipartUpload{
+	out := InitiateMultipartUploadResult{
 		UploadID: uploadID,
 		Bucket:   bucket,
 		Key:      object,

--- a/messages.go
+++ b/messages.go
@@ -169,7 +169,7 @@ func (er ErrorResult) String() string {
 	return fmt.Sprintf("%s: [%s] %s", er.Key, er.Code, er.Message)
 }
 
-type InitiateMultipartUpload struct {
+type InitiateMultipartUploadResult struct {
 	Bucket   string   `xml:"Bucket"`
 	Key      string   `xml:"Key"`
 	UploadID UploadID `xml:"UploadId"`


### PR DESCRIPTION
Hi! 
In this pull request i want to fix two mismatches with aws s3 api:

1. Root element of create multipart upload response is `InitiateMultipartUploadResult` instead of `InitiateMultipartUpload`
https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html#API_CreateMultipartUpload_ResponseSyntax
3. ETag in complete multipart upload response is md5 digest of concatenated md5 digests of parts with number of parts after dash
https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums