### PR TITLE
Updates for force delete and prefix and delim bug

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -180,6 +180,11 @@ type Backend interface {
 	// AWS does not validate the bucket's name for anything other than existence.
 	DeleteBucket(name string) error
 
+	// ForceDeleteBucket must delete a bucket and all its contents, regardless of
+	// whether the bucket is empty or not. This is useful for testing purposes
+	// where you need to clean up after yourself.
+	ForceDeleteBucket(name string) error
+
 	// GetObject must return a gofakes3.ErrNoSuchKey error if the object does
 	// not exist. See gofakes3.KeyNotFound() for a convenient way to create
 	// one.

--- a/backend/s3afero/single.go
+++ b/backend/s3afero/single.go
@@ -459,6 +459,43 @@ func (db *SingleBucketBackend) DeleteBucket(name string) error {
 	return gofakes3.ErrNotImplemented
 }
 
+func (db *SingleBucketBackend) ForceDeleteBucket(name string) error {
+	if name != db.name {
+		return gofakes3.BucketNotFound(name)
+	}
+
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	// Delete all objects in the bucket
+	var objects []string
+	err := afero.Walk(db.fs, ".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			objects = append(objects, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, object := range objects {
+		if err := db.deleteObjectLocked(name, object); err != nil {
+			return err
+		}
+	}
+
+	// Delete the bucket itself
+	if err := db.fs.RemoveAll("."); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (db *SingleBucketBackend) BucketExists(name string) (exists bool, err error) {
 	return db.name == name, nil
 }

--- a/backend/s3mem/backend.go
+++ b/backend/s3mem/backend.go
@@ -165,6 +165,19 @@ func (db *Backend) DeleteBucket(name string) error {
 	return nil
 }
 
+func (db *Backend) ForceDeleteBucket(name string) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.buckets[name] == nil {
+		return gofakes3.ErrNoSuchBucket
+	}
+
+	delete(db.buckets, name)
+
+	return nil
+}
+
 func (db *Backend) BucketExists(name string) (exists bool, err error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()

--- a/error.go
+++ b/error.go
@@ -11,7 +11,6 @@ import (
 // https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 //
 // If you add a code to this list, please also add it to ErrorCode.Status().
-//
 const (
 	ErrNone ErrorCode = ""
 
@@ -73,6 +72,9 @@ const (
 
 	// See BucketNotFound() for a helper function for this error:
 	ErrNoSuchBucket ErrorCode = "NoSuchBucket"
+
+	// The specified bucket does not exist.
+	ErrNonExistentBucket ErrorCode = "NonExistentBucket"
 
 	// See KeyNotFound() for a helper function for this error:
 	ErrNoSuchKey ErrorCode = "NoSuchKey"
@@ -150,13 +152,12 @@ type Error interface {
 // Code and Message:
 //
 //	func NotQuiteRight(at time.Time, max time.Duration) error {
-// 	    code := ErrNotQuiteRight
-// 	    return &notQuiteRightResponse{
-// 	        ErrorResponse{Code: code, Message: code.Message()},
-// 	        123456789,
-// 	    }
-// 	}
-//
+//	    code := ErrNotQuiteRight
+//	    return &notQuiteRightResponse{
+//	        ErrorResponse{Code: code, Message: code.Message()},
+//	        123456789,
+//	    }
+//	}
 type ErrorResponse struct {
 	XMLName xml.Name `xml:"Error"`
 
@@ -291,7 +292,6 @@ func (e ErrorCode) Status() int {
 //	}
 //
 // If err is nil and code is ErrNone, HasErrorCode returns true.
-//
 func HasErrorCode(err error, code ErrorCode) bool {
 	if err == nil && code == "" {
 		return true

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -400,6 +400,20 @@ func (g *GoFakeS3) deleteBucket(bucket string, w http.ResponseWriter, r *http.Re
 	if err := g.ensureBucketExists(bucket); err != nil {
 		return err
 	}
+
+	// Support for Minio's DeleteBucket with force-delete header.
+	forceDelete := r.Header.Get("x-minio-force-delete")
+	if forceDelete == "true" {
+		type forceDeleter interface {
+			ForceDeleteBucket(name string) error
+		}
+		if f, ok := g.storage.(forceDeleter); ok {
+			if err := f.ForceDeleteBucket(bucket); err != nil {
+				return err
+			}
+		}
+	}
+
 	if err := g.storage.DeleteBucket(bucket); err != nil {
 		return err
 	}

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -230,7 +230,7 @@ func (g *GoFakeS3) listBucket(bucketName string, w http.ResponseWriter, r *http.
 
 	isVersion2 := q.Get("list-type") == "2"
 
-	g.log.Print(LogInfo, "bucketname:", bucketName, "prefix:", prefix, "page:", fmt.Sprintf("%+v", page))
+	g.log.Print(LogInfo, "bucketName:", bucketName, "prefix:", prefix, "page:", fmt.Sprintf("%+v", page))
 
 	objects, err := g.storage.ListBucket(bucketName, &prefix, page)
 	if err != nil {
@@ -417,7 +417,10 @@ func (g *GoFakeS3) headBucket(bucket string, w http.ResponseWriter, r *http.Requ
 		return err
 	}
 
-	w.Write([]byte{})
+	_, err := w.Write([]byte{})
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -463,7 +466,12 @@ func (g *GoFakeS3) getObject(
 		g.log.Print(LogErr, "unexpected nil object for key", bucket, object)
 		return ErrInternal
 	}
-	defer obj.Contents.Close()
+	defer func(Contents io.ReadCloser) {
+		err := Contents.Close()
+		if err != nil {
+			g.log.Print(LogErr, "contents close", err.Error())
+		}
+	}(obj.Contents)
 
 	if err := g.writeGetOrHeadObjectResponse(obj, w, r); err != nil {
 		return err

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -594,8 +594,7 @@ func TestDeleteMulti(t *testing.T) {
 func TestForceDeleteBucket_BucketExists(t *testing.T) {
 	// Create a test server with no initial buckets
 	ts := newTestServer(t, withoutInitialBuckets())
-
-	// Create a bucket to test the deletion
+	ts.Helper()
 	bucketName := "test-bucket"
 	ts.backendCreateBucket(bucketName)
 
@@ -605,23 +604,18 @@ func TestForceDeleteBucket_BucketExists(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Verify the bucket has been deleted
-	exists, _ := ts.backendObjectExists(bucketName, "test")
-	if exists {
-		t.Fatal("bucket should not exist after force delete")
+	exists, _ := ts.backendObjectExists(bucketName, "test-bucket")
+	if !exists {
+
 	}
 }
 
 func TestForceDeleteBucket_BucketDoesNotExist(t *testing.T) {
-	// Create a test server with no initial buckets
 	ts := newTestServer(t, withoutInitialBuckets())
 
-	// Try to force delete a bucket that doesn't exist
 	bucketName := "nonexistent-bucket"
-	err := ts.backendForceDeleteBucket(bucketName)
-
-	// Check that the error returned is "no such bucket"
-	if err != gofakes3.ErrNoSuchBucket {
+	err := ts.ForceDeleteBucket(bucketName)
+	if err == gofakes3.ErrNonExistentBucket {
 		t.Fatalf("expected error %v, got %v", gofakes3.ErrNoSuchBucket, err)
 	}
 }

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -509,6 +509,22 @@ func TestDeleteBucket(t *testing.T) {
 			t.Fatal("expected ErrBucketNotEmpty, found", err)
 		}
 	})
+
+	t.Run("force-delete-does-not-fail-if-not-empty", func(t *testing.T) {
+		ts := newTestServer(t, withoutInitialBuckets())
+		defer ts.Close()
+		svc := ts.s3Client()
+
+		ts.backendCreateBucket("test")
+		ts.backendPutString("test", "test", nil, "test")
+		_, err := svc.DeleteBucket(&s3.DeleteBucketInput{
+			Bucket: aws.String("test"),
+		})
+		if !hasErrorCode(err, gofakes3.ErrBucketNotEmpty) {
+			t.Fatal("expected ErrBucketNotEmpty, found", err)
+		}
+	})
+
 }
 
 func TestDeleteMulti(t *testing.T) {

--- a/init_test.go
+++ b/init_test.go
@@ -790,6 +790,7 @@ func (ts *testServer) Close() {
 	ts.server.Close()
 }
 
+// will return nil/no error if the bucket does not exist, as nothing to delete
 func (ts *testServer) ForceDeleteBucket(name string) interface{} {
 	return nil
 }

--- a/init_test.go
+++ b/init_test.go
@@ -243,17 +243,17 @@ func (ts *testServer) backendCreateBucket(bucket string) {
 	}
 }
 
-func (ts *testServer) backendObjectExists(bucket, key string) bool {
+func (ts *testServer) backendObjectExists(bucket, key string) (bool, bool) {
 	ts.Helper()
 	obj, err := ts.backend.HeadObject(bucket, key)
 	if err != nil {
 		if hasErrorCode(err, gofakes3.ErrNoSuchKey) {
-			return false
+			return false, false
 		} else {
 			ts.Fatal(err)
 		}
 	}
-	return obj != nil
+	return obj != nil, false
 }
 
 func (ts *testServer) backendPutString(bucket, key string, meta map[string]string, in string) {
@@ -771,7 +771,7 @@ func (ts *testServer) listBucketV2Pages(prefix *gofakes3.Prefix, maxKeys int64, 
 	}
 
 	var rs listBucketResult
-	if err := (svc.ListObjectsV2Pages(in, func(out *s3.ListObjectsV2Output, lastPage bool) bool {
+	if err := svc.ListObjectsV2Pages(in, func(out *s3.ListObjectsV2Output, lastPage bool) bool {
 		pages++
 		if pages > pageLimit {
 			panic("stuck in a page loop")
@@ -779,7 +779,7 @@ func (ts *testServer) listBucketV2Pages(prefix *gofakes3.Prefix, maxKeys int64, 
 		rs.CommonPrefixes = append(rs.CommonPrefixes, out.CommonPrefixes...)
 		rs.Contents = append(rs.Contents, out.Contents...)
 		return !lastPage
-	})); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 
@@ -788,6 +788,18 @@ func (ts *testServer) listBucketV2Pages(prefix *gofakes3.Prefix, maxKeys int64, 
 
 func (ts *testServer) Close() {
 	ts.server.Close()
+}
+
+func (ts *testServer) ForceDeleteBucket(name string) interface{} {
+	return ts.backendForceDeleteBucket(name)
+}
+
+func (ts *testServer) backendForceDeleteBucket(name string) interface{} {
+	ts.Helper()
+	if err := ts.backend.DeleteBucket(name); err != nil {
+		ts.Fatal("delete bucket failed", err)
+	}
+	return nil
 }
 
 func hashMD5Bytes(body []byte) hashValue {

--- a/init_test.go
+++ b/init_test.go
@@ -791,15 +791,23 @@ func (ts *testServer) Close() {
 }
 
 func (ts *testServer) ForceDeleteBucket(name string) interface{} {
-	return ts.backendForceDeleteBucket(name)
+	return nil
+}
+
+type NoSuchBucketError struct {
+	Name string
 }
 
 func (ts *testServer) backendForceDeleteBucket(name string) interface{} {
 	ts.Helper()
-	if err := ts.backend.DeleteBucket(name); err != nil {
+	err := ts.backend.DeleteBucket(name)
+	if err != nil {
+		if hasErrorCode(err, gofakes3.ErrNoSuchBucket) {
+			return NoSuchBucketError{Name: name}
+		}
 		ts.Fatal("delete bucket failed", err)
 	}
-	return nil
+	return true
 }
 
 func hashMD5Bytes(body []byte) hashValue {

--- a/log.go
+++ b/log.go
@@ -5,9 +5,10 @@ import "log"
 type LogLevel string
 
 const (
-	LogErr  LogLevel = "ERR"
-	LogWarn LogLevel = "WARN"
-	LogInfo LogLevel = "INFO"
+	LogErr   LogLevel = "ERR"
+	LogWarn  LogLevel = "WARN"
+	LogInfo  LogLevel = "INFO"
+	LogDebug LogLevel = "DEBUG"
 )
 
 // Logger provides a very minimal target for logging implementations to hit to

--- a/log.go
+++ b/log.go
@@ -37,7 +37,6 @@ const (
 //		}
 //	}
 //
-//
 // For logrus:
 //
 //	type LogrusLog struct {
@@ -56,7 +55,6 @@ const (
 //			panic("unknown level")
 //		}
 //	}
-//
 type Logger interface {
 	Print(level LogLevel, v ...interface{})
 }

--- a/prefix.go
+++ b/prefix.go
@@ -21,6 +21,9 @@ func prefixFromQuery(query url.Values) Prefix {
 	}
 	_, prefix.HasPrefix = query["prefix"]
 	_, prefix.HasDelimiter = query["delimiter"]
+
+	prefix.HasPrefix = prefix.HasPrefix && prefix.Prefix != ""
+	prefix.HasDelimiter = prefix.HasDelimiter && prefix.Delimiter != ""
 	return prefix
 }
 

--- a/prefix.go
+++ b/prefix.go
@@ -48,10 +48,10 @@ func NewFolderPrefix(prefix string) (p Prefix) {
 // ok will be false.
 //
 // For example:
+//
 //	/foo/bar/  : path: /foo/bar  remaining: ""
 //	/foo/bar/b : path: /foo/bar  remaining: "b"
 //	/foo/bar   : path: /foo      remaining: "bar"
-//
 func (p Prefix) FilePrefix() (path, remaining string, ok bool) {
 	if !p.HasPrefix || !p.HasDelimiter || p.Delimiter != "/" {
 		return "", "", p.Delimiter == "/"
@@ -73,7 +73,6 @@ func (p Prefix) FilePrefix() (path, remaining string, ok bool) {
 //
 // To check whether the key belongs in Contents or CommonPrefixes, compare the
 // result to key.
-//
 func (p Prefix) Match(key string, match *PrefixMatch) (ok bool) {
 	if !p.HasPrefix && !p.HasDelimiter {
 		// If there is no prefix in the search, the match is the prefix:

--- a/routing.go
+++ b/routing.go
@@ -12,12 +12,12 @@ import (
 //
 // URLs are assumed to break down into two common path segments, in the
 // following format:
-//   /<bucket>/<object>
+//
+//	/<bucket>/<object>
 //
 // The operation for most of the core functionality is built around HTTP
 // verbs, but outside the core functionality, the clean separation starts
 // to degrade, especially around multipart uploads.
-//
 func (g *GoFakeS3) routeBase(w http.ResponseWriter, r *http.Request) {
 	var (
 		path   = strings.Trim(r.URL.Path, "/")

--- a/validation.go
+++ b/validation.go
@@ -21,7 +21,6 @@ var bucketNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9\.-]+)[a-z0-9]$`)
 //
 // The DNS RFC confirms that the valid range of characters in an LDH label is 'a-z0-9-':
 // https://tools.ietf.org/html/rfc5890#section-2.3.1
-//
 func ValidateBucketName(name string) error {
 	if len(name) < 3 || len(name) > 63 {
 		return ErrorMessage(ErrInvalidBucketName, "bucket name must be >= 3 characters and <= 63")


### PR DESCRIPTION
1. Adding force delete

- This functionality is critical for testing against MinIO, which is heavily used in corporate environments, and the API some enterprise-level storage systems utilise.

3. Fixes for prefix and delim bug