### PR TITLE
Optionally allow all methods and headers in CORS preflight

### DIFF
--- a/cmd/gofakes3/main.go
+++ b/cmd/gofakes3/main.go
@@ -38,6 +38,7 @@ type fakeS3Flags struct {
 	hostBucket      bool
 	hostBucketBases HostList
 	autoBucket      bool
+	insecureCORS    bool
 	quiet           bool
 
 	boltDb              string
@@ -59,6 +60,7 @@ func (f *fakeS3Flags) attach(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&f.fixedTimeStr, "time", "", "RFC3339 format. If passed, the server's clock will always see this time; does not affect existing stored dates.")
 	flagSet.StringVar(&f.initialBucket, "initialbucket", "", "If passed, this bucket will be created on startup if it does not already exist.")
 	flagSet.BoolVar(&f.noIntegrity, "no-integrity", false, "Pass this flag to disable Content-MD5 validation when uploading.")
+	flagSet.BoolVar(&f.insecureCORS, "insecure-cors", false, "If true, CORS headers in preflight requests will always allow anything.")
 	flagSet.BoolVar(&f.autoBucket, "autobucket", false, "If passed, nonexistent buckets will be created on first use instead of raising an error")
 	flagSet.BoolVar(&f.hostBucket, "hostbucket", false, ""+
 		"If passed, the bucket name will be extracted from the first segment of the hostname, "+
@@ -261,7 +263,7 @@ func run() error {
 		logger = gofakes3.DiscardLog()
 	}
 
-	faker := gofakes3.New(backend,
+	options := []gofakes3.Option{
 		gofakes3.WithIntegrityCheck(!values.noIntegrity),
 		gofakes3.WithTimeSkewLimit(timeSkewLimit),
 		gofakes3.WithTimeSource(timeSource),
@@ -269,7 +271,13 @@ func run() error {
 		gofakes3.WithHostBucket(values.hostBucket),
 		gofakes3.WithHostBucketBase(values.hostBucketBases.Values...),
 		gofakes3.WithAutoBucket(values.autoBucket),
-	)
+	}
+
+	if values.insecureCORS {
+		options = append(options, gofakes3.WithInsecureCORS())
+	}
+
+	faker := gofakes3.New(backend, options...)
 
 	return listenAndServe(values.host, faker.Server())
 }

--- a/cors_test.go
+++ b/cors_test.go
@@ -1,0 +1,67 @@
+package gofakes3
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWrapInsecureCORSOptionsRequest(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	corsHandler := wrapInsecureCORS(h)
+
+	req := httptest.NewRequest("OPTIONS", "/", nil)
+	req.Header.Set("Origin", "foo")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	resp := httptest.NewRecorder()
+	corsHandler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status OK; got %v", resp.Code)
+	}
+
+	headers := resp.Header()
+	if headers.Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("Expected Access-Control-Allow-Origin: *; got %v", headers.Get("Access-Control-Allow-Origin"))
+	}
+	if headers.Get("Access-Control-Allow-Methods") != "*" {
+		t.Errorf("Expected Access-Control-Allow-Methods: *; got %v", headers.Get("Access-Control-Allow-Methods"))
+	}
+	if headers.Get("Access-Control-Allow-Headers") != "*" {
+		t.Errorf("Expected Access-Control-Allow-Headers: *; got %v", headers.Get("Access-Control-Allow-Headers"))
+	}
+	if headers.Get("Access-Control-Expose-Headers") != "*" {
+		t.Errorf("Expected Access-Control-Expose-Headers: *; got %v", headers.Get("Access-Control-Expose-Headers"))
+	}
+}
+
+func TestWrapInsecureCORSGetRequest(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	corsHandler := wrapInsecureCORS(h)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	resp := httptest.NewRecorder()
+	corsHandler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status OK; got %v", resp.Code)
+	}
+
+	headers := resp.Header()
+	if _, ok := headers["Access-Control-Allow-Origin"]; ok {
+		t.Errorf("expected no Access-Control-Allow-Origin header")
+	}
+	if _, ok := headers["Access-Control-Allow-Methods"]; ok {
+		t.Errorf("expected no Access-Control-Allow-Methods header")
+	}
+	if _, ok := headers["Access-Control-Allow-Headers"]; ok {
+		t.Errorf("expected no Access-Control-Allow-Headers header")
+	}
+	if _, ok := headers["Access-Control-Expose-Headers"]; ok {
+		t.Errorf("expected no Access-Control-Expose-Headers header")
+	}
+}

--- a/option.go
+++ b/option.go
@@ -101,3 +101,8 @@ func WithUnimplementedPageError() Option {
 func WithAutoBucket(enabled bool) Option {
 	return func(g *GoFakeS3) { g.autoBucket = enabled }
 }
+
+// WithInsecureCORS responds with * for all Access-Control-Allow headers.
+func WithInsecureCORS() Option {
+	return func(g *GoFakeS3) { g.wrapCORS = wrapInsecureCORS }
+}


### PR DESCRIPTION
I ran into an issue with the presigned URL emulation where my browser was sending headers we weren't set up to accept. I started out making some overblown thing that'd let us pass all the cors things via flags, but nobody's asked for that yet and I don't need it here, I just need to be able to have the CORS preflight say "yep everything's fine, no worries" as it's just a local development context I'm working in.

I was also trying to be minimally disruptive so I've tried to leave it so it would continue to work largely as it did, but that's not strictly necessary. Another option is that we could adopt https://github.com/rs/cors (which has zero dependencies) and junk the "just enough CORS to make it go away" handler we've got.

If you start the server with `go run ./cmd/gofakes3 -backend mem` and make a preflight request using cURL with `curl -i -X OPTIONS -H 'Access-Control-Request-Method: GET' -H 'Origin: foo' http://localhost:9000/`, you get this result, which should be the same as before:

```
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Accept, Accept-Encoding, Authorization, cache-control, Content-Disposition, Content-Encoding, Content-Length, Content-Type, X-Amz-Date, X-Amz-User-Agent, X-CSRF-Token, x-amz-acl, x-amz-content-sha256, x-amz-meta-filename, x-amz-meta-from, x-amz-meta-private, x-amz-meta-to, x-amz-security-token, x-requested-with
Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE, HEAD
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: ETag
Date: Wed, 02 Apr 2025 05:10:51 GMT
Content-Length: 0
```

If you start the server like this: `go run ./cmd/gofakes3 -backend mem -insecure-cors=true`, you get this result:

```
HTTP/1.1 200 OK
Access-Control-Allow-Headers: *
Access-Control-Allow-Methods: *
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: *
Date: Wed, 02 Apr 2025 05:11:30 GMT
Content-Length: 0
``` 

Perhaps the flag is deceptive as I can't imagine the current CORS handler _isn't_ insecure, even with the flag off, but maybe that's a question for another PR?