### PR TITLE
 Conditional Write (IfMatch and IfNoneMatch) support for PutObject 

### DIFF
--- a/backend/s3afero/backend_test.go
+++ b/backend/s3afero/backend_test.go
@@ -10,8 +10,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/johannesboyne/gofakes3"
 	"github.com/spf13/afero"
+
+	"github.com/johannesboyne/gofakes3"
 )
 
 func testingBackends(t *testing.T) []gofakes3.Backend {
@@ -43,7 +44,7 @@ func TestPutGet(t *testing.T) {
 			}
 
 			contents := []byte("contents")
-			if _, err := backend.PutObject("test", "yep", meta, bytes.NewReader(contents), int64(len(contents))); err != nil {
+			if _, err := backend.PutObject("test", "yep", meta, bytes.NewReader(contents), int64(len(contents)), nil); err != nil {
 				t.Fatal(err)
 			}
 			hasher := md5.New()
@@ -89,7 +90,7 @@ func TestPutGetRange(t *testing.T) {
 
 			contents := []byte("contents")
 			expected := contents[1:7]
-			if _, err := backend.PutObject("test", "yep", meta, bytes.NewReader(contents), int64(len(contents))); err != nil {
+			if _, err := backend.PutObject("test", "yep", meta, bytes.NewReader(contents), int64(len(contents)), nil); err != nil {
 				t.Fatal(err)
 			}
 			hasher := md5.New()
@@ -134,12 +135,12 @@ func TestPutListRoot(t *testing.T) {
 			}
 
 			contents1 := []byte("contents1")
-			if _, err := backend.PutObject("test", "foo", meta, bytes.NewReader(contents1), int64(len(contents1))); err != nil {
+			if _, err := backend.PutObject("test", "foo", meta, bytes.NewReader(contents1), int64(len(contents1)), nil); err != nil {
 				t.Fatal(err)
 			}
 
 			contents2 := []byte("contents2")
-			if _, err := backend.PutObject("test", "bar", meta, bytes.NewReader(contents2), int64(len(contents2))); err != nil {
+			if _, err := backend.PutObject("test", "bar", meta, bytes.NewReader(contents2), int64(len(contents2)), nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -180,12 +181,12 @@ func TestPutListDir(t *testing.T) {
 			}
 
 			contents1 := []byte("contents1")
-			if _, err := backend.PutObject("test", "foo/bar", meta, bytes.NewReader(contents1), int64(len(contents1))); err != nil {
+			if _, err := backend.PutObject("test", "foo/bar", meta, bytes.NewReader(contents1), int64(len(contents1)), nil); err != nil {
 				t.Fatal(err)
 			}
 
 			contents2 := []byte("contents2")
-			if _, err := backend.PutObject("test", "foo/baz", meta, bytes.NewReader(contents2), int64(len(contents2))); err != nil {
+			if _, err := backend.PutObject("test", "foo/baz", meta, bytes.NewReader(contents2), int64(len(contents2)), nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -226,7 +227,7 @@ func TestPutDelete(t *testing.T) {
 			}
 
 			contents := []byte("contents1")
-			if _, err := backend.PutObject("test", "foo", meta, bytes.NewReader(contents), int64(len(contents))); err != nil {
+			if _, err := backend.PutObject("test", "foo", meta, bytes.NewReader(contents), int64(len(contents)), nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -258,12 +259,12 @@ func TestPutDeleteMulti(t *testing.T) {
 			}
 
 			contents1 := []byte("contents1")
-			if _, err := backend.PutObject("test", "foo/bar", meta, bytes.NewReader(contents1), int64(len(contents1))); err != nil {
+			if _, err := backend.PutObject("test", "foo/bar", meta, bytes.NewReader(contents1), int64(len(contents1)), nil); err != nil {
 				t.Fatal(err)
 			}
 
 			contents2 := []byte("contents2")
-			if _, err := backend.PutObject("test", "foo/baz", meta, bytes.NewReader(contents2), int64(len(contents2))); err != nil {
+			if _, err := backend.PutObject("test", "foo/baz", meta, bytes.NewReader(contents2), int64(len(contents2)), nil); err != nil {
 				t.Fatal(err)
 			}
 

--- a/backend/s3mem/bucket.go
+++ b/backend/s3mem/bucket.go
@@ -118,7 +118,6 @@ type bucketData struct {
 	deleteMarker bool
 	body         []byte
 	hash         []byte
-	etag         string
 	metadata     map[string]string
 }
 

--- a/conditional_put_test.go
+++ b/conditional_put_test.go
@@ -1,0 +1,386 @@
+package gofakes3_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/spf13/afero"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/johannesboyne/gofakes3"
+	"github.com/johannesboyne/gofakes3/backend/s3afero"
+	"github.com/johannesboyne/gofakes3/backend/s3bolt"
+	"github.com/johannesboyne/gofakes3/backend/s3mem"
+)
+
+// backendTestCase represents a backend configuration for testing
+type backendTestCase struct {
+	name    string
+	backend gofakes3.Backend
+	cleanup func() // Optional cleanup function
+}
+
+// createAllBackends creates instances of all available backends for testing
+func createAllBackends(t *testing.T) []backendTestCase {
+	t.Helper()
+
+	var backends []backendTestCase
+
+	// 1. s3mem backend
+	backends = append(backends, backendTestCase{
+		name:    "s3mem",
+		backend: s3mem.New(s3mem.WithTimeSource(gofakes3.FixedTimeSource(defaultDate))),
+		cleanup: nil,
+	})
+
+	// 2. s3bolt backend
+	tempBoltFile, err := ioutil.TempFile("", "gofakes3-test-*.db")
+	if err != nil {
+		t.Fatal("Failed to create temp bolt file:", err)
+	}
+	tempBoltFile.Close()
+
+	boltDB, err := bolt.Open(tempBoltFile.Name(), 0600, nil)
+	if err != nil {
+		os.Remove(tempBoltFile.Name())
+		t.Fatal("Failed to open bolt database:", err)
+	}
+
+	boltBackend := s3bolt.New(boltDB, s3bolt.WithTimeSource(gofakes3.FixedTimeSource(defaultDate)))
+
+	backends = append(backends, backendTestCase{
+		name:    "s3bolt",
+		backend: boltBackend,
+		cleanup: func() {
+			boltDB.Close()
+			os.Remove(tempBoltFile.Name())
+		},
+	})
+
+	// 3. s3afero SingleBucket backend (use defaultBucket name to match test expectations)
+	singleBackend, err := s3afero.SingleBucket(defaultBucket, afero.NewMemMapFs(), nil)
+	if err != nil {
+		t.Fatal("Failed to create s3afero single backend:", err)
+	}
+
+	backends = append(backends, backendTestCase{
+		name:    "s3afero-single",
+		backend: singleBackend,
+		cleanup: nil,
+	})
+
+	// 4. s3afero MultiBucket backend
+	multiBackend, err := s3afero.MultiBucket(afero.NewMemMapFs())
+	if err != nil {
+		t.Fatal("Failed to create s3afero multi backend:", err)
+	}
+
+	backends = append(backends, backendTestCase{
+		name:    "s3afero-multi",
+		backend: multiBackend,
+		cleanup: nil,
+	})
+
+	return backends
+}
+
+// runWithAllBackends runs a test function against all backend implementations
+func runWithAllBackends(t *testing.T, testFunc func(*testing.T, *testServer)) {
+	backends := createAllBackends(t)
+
+	for _, backendCase := range backends {
+		t.Run(backendCase.name, func(t *testing.T) {
+			// Ensure cleanup happens even if test fails
+			if backendCase.cleanup != nil {
+				defer backendCase.cleanup()
+			}
+
+			// Create test server with this backend
+			var ts *testServer
+			if backendCase.name == "s3afero-single" {
+				// SingleBucket backend already has the bucket, don't try to create it
+				ts = newTestServer(t, withBackend(backendCase.backend), withoutInitialBuckets())
+			} else {
+				ts = newTestServer(t, withBackend(backendCase.backend))
+			}
+			defer ts.Close()
+
+			// Run the test function
+			testFunc(t, ts)
+		})
+	}
+}
+
+func TestConditionalPutIfNoneMatch(t *testing.T) {
+	runWithAllBackends(t, testConditionalPutIfNoneMatch)
+}
+
+func testConditionalPutIfNoneMatch(t *testing.T, ts *testServer) {
+	svc := ts.s3Client()
+
+	bucket := aws.String(defaultBucket)
+	key := aws.String("test-object")
+	body := []byte("test content")
+
+	// Test 1: If-None-Match with * should succeed when object doesn't exist
+	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader(body),
+	})
+	req.HTTPRequest.Header.Set("If-None-Match", "*")
+	err := req.Send()
+	if err != nil {
+		t.Fatal("Expected success when object doesn't exist:", err)
+	}
+
+	// Test 2: If-None-Match with * should fail when object exists
+	req2, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader([]byte("new content")),
+	})
+	req2.HTTPRequest.Header.Set("If-None-Match", "*")
+	err = req2.Send()
+	if err == nil {
+		t.Fatal("Expected failure when object exists")
+	}
+	if !hasErrorCode(err, gofakes3.ErrPreconditionFailed) {
+		t.Fatal("Expected PreconditionFailed error, got:", err)
+	}
+
+	// Verify original content is unchanged
+	obj := ts.backendGetString(defaultBucket, "test-object", nil)
+	if obj != "test content" {
+		t.Fatal("Object content was modified when it shouldn't have been")
+	}
+}
+
+func TestConditionalPutIfMatch(t *testing.T) {
+	runWithAllBackends(t, testConditionalPutIfMatch)
+}
+
+func testConditionalPutIfMatch(t *testing.T, ts *testServer) {
+	svc := ts.s3Client()
+
+	bucket := aws.String(defaultBucket)
+	key := aws.String("test-object")
+	body := []byte("test content")
+
+	// Create initial object
+	putResp, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader(body),
+	})
+	if err != nil {
+		t.Fatal("Failed to create initial object:", err)
+	}
+	etag := *putResp.ETag
+
+	// Test 1: If-Match with correct ETag should succeed
+	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader([]byte("updated content")),
+	})
+	req.HTTPRequest.Header.Set("If-Match", etag)
+	err = req.Send()
+	if err != nil {
+		t.Fatal("Expected success with matching ETag:", err)
+	}
+
+	// Test 2: If-Match with wrong ETag should fail
+	req2, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader([]byte("another update")),
+	})
+	req2.HTTPRequest.Header.Set("If-Match", `"wrong-etag"`)
+	err = req2.Send()
+	if err == nil {
+		t.Fatal("Expected failure with wrong ETag")
+	}
+	if !hasErrorCode(err, gofakes3.ErrPreconditionFailed) {
+		t.Fatal("Expected PreconditionFailed error, got:", err)
+	}
+
+	// Verify content is the updated content, not the failed update
+	obj := ts.backendGetString(defaultBucket, "test-object", nil)
+	if obj != "updated content" {
+		t.Fatal("Object content is not the expected updated content")
+	}
+}
+
+func TestConditionalPutNonExistentObject(t *testing.T) {
+	runWithAllBackends(t, testConditionalPutNonExistentObject)
+}
+
+func testConditionalPutNonExistentObject(t *testing.T, ts *testServer) {
+	svc := ts.s3Client()
+
+	bucket := aws.String(defaultBucket)
+	key := aws.String("nonexistent-object")
+
+	// Test: If-Match on non-existent object should fail
+	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader([]byte("content")),
+	})
+	req.HTTPRequest.Header.Set("If-Match", `"some-etag"`)
+	err := req.Send()
+	if err == nil {
+		t.Fatal("Expected failure when object doesn't exist")
+	}
+	if !hasErrorCode(err, gofakes3.ErrPreconditionFailed) {
+		t.Fatal("Expected PreconditionFailed error, got:", err)
+	}
+
+	// Verify object was not created
+	if exists, _ := ts.backendObjectExists(defaultBucket, "nonexistent-object"); exists {
+		t.Fatal("Object should not have been created")
+	}
+}
+
+func TestConditionalPutMultipleConditions(t *testing.T) {
+	runWithAllBackends(t, testConditionalPutMultipleConditions)
+}
+
+func testConditionalPutMultipleConditions(t *testing.T, ts *testServer) {
+	svc := ts.s3Client()
+
+	bucket := aws.String(defaultBucket)
+	key := aws.String("test-object")
+	body := []byte("test content")
+
+	// Create initial object
+	putResp, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader(body),
+	})
+	if err != nil {
+		t.Fatal("Failed to create initial object:", err)
+	}
+	etag := *putResp.ETag
+
+	// Test: If-Match condition should pass
+	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader([]byte("updated content")),
+	})
+	req.HTTPRequest.Header.Set("If-Match", etag)
+	err = req.Send()
+	if err != nil {
+		t.Fatal("Expected success with If-Match condition:", err)
+	}
+
+	// Verify content was updated
+	obj := ts.backendGetString(defaultBucket, "test-object", nil)
+	if obj != "updated content" {
+		t.Fatal("Object content was not updated")
+	}
+}
+
+func TestConditionalPutCopyOperation(t *testing.T) {
+	runWithAllBackends(t, testConditionalPutCopyOperation)
+}
+
+func testConditionalPutCopyOperation(t *testing.T, ts *testServer) {
+	svc := ts.s3Client()
+
+	bucket := aws.String(defaultBucket)
+	sourceKey := aws.String("source-object")
+	destKey := aws.String("dest-object")
+
+	// Create source object
+	_, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    sourceKey,
+		Body:   bytes.NewReader([]byte("source content")),
+	})
+	if err != nil {
+		t.Fatal("Failed to create source object:", err)
+	}
+
+	// Test: Copy operation should not be affected by conditional headers
+	// (copy operations always pass nil conditions to backend)
+	_, err = svc.CopyObject(&s3.CopyObjectInput{
+		Bucket:     bucket,
+		Key:        destKey,
+		CopySource: aws.String(defaultBucket + "/" + *sourceKey),
+	})
+	if err != nil {
+		t.Fatal("Copy operation failed:", err)
+	}
+
+	// Verify copy succeeded
+	obj := ts.backendGetString(defaultBucket, "dest-object", nil)
+	if obj != "source content" {
+		t.Fatal("Copy operation did not work correctly")
+	}
+}
+
+func TestConditionalPutETagComparison(t *testing.T) {
+	runWithAllBackends(t, testConditionalPutETagComparison)
+}
+
+func testConditionalPutETagComparison(t *testing.T, ts *testServer) {
+	svc := ts.s3Client()
+
+	bucket := aws.String(defaultBucket)
+	key := aws.String("test-object")
+	body := []byte("test content")
+
+	// Create initial object
+	putResp, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader(body),
+	})
+	if err != nil {
+		t.Fatal("Failed to create initial object:", err)
+	}
+	etag := *putResp.ETag
+
+	// Test 1: ETag with quotes should work
+	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader([]byte("updated content 1")),
+	})
+	req.HTTPRequest.Header.Set("If-Match", etag) // ETag already has quotes
+	err = req.Send()
+	if err != nil {
+		t.Fatal("Expected success with quoted ETag:", err)
+	}
+
+	// Get new ETag
+	getResp, err := svc.GetObject(&s3.GetObjectInput{
+		Bucket: bucket,
+		Key:    key,
+	})
+	if err != nil {
+		t.Fatal("Failed to get object:", err)
+	}
+	newEtag := *getResp.ETag
+
+	// Test 2: ETag without quotes should also work
+	unquotedEtag := newEtag[1 : len(newEtag)-1] // Remove quotes
+	req2, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Body:   bytes.NewReader([]byte("updated content 2")),
+	})
+	req2.HTTPRequest.Header.Set("If-Match", unquotedEtag)
+	err = req2.Send()
+	if err != nil {
+		t.Fatal("Expected success with unquoted ETag:", err)
+	}
+}

--- a/error.go
+++ b/error.go
@@ -88,6 +88,12 @@ const (
 	// No need to retransmit the object
 	ErrNotModified ErrorCode = "NotModified"
 
+	// At least one of the preconditions you specified did not hold
+	ErrPreconditionFailed ErrorCode = "PreconditionFailed"
+
+	// A conflicting conditional operation is currently in progress against this resource
+	ErrConditionalRequestConflict ErrorCode = "ConditionalRequestConflict"
+
 	ErrRequestTimeTooSkewed ErrorCode = "RequestTimeTooSkewed"
 	ErrTooManyBuckets       ErrorCode = "TooManyBuckets"
 	ErrNotImplemented       ErrorCode = "NotImplemented"
@@ -226,6 +232,10 @@ func (e ErrorCode) Message() string {
 		return "The difference between the request time and the current time is too large"
 	case ErrMalformedXML:
 		return "The XML you provided was not well-formed or did not validate against our published schema"
+	case ErrPreconditionFailed:
+		return "At least one of the preconditions you specified did not hold"
+	case ErrConditionalRequestConflict:
+		return "A conflicting conditional operation is currently in progress against this resource"
 	default:
 		return ""
 	}
@@ -236,6 +246,12 @@ func (e ErrorCode) Status() int {
 	case ErrBucketAlreadyExists,
 		ErrBucketNotEmpty:
 		return http.StatusConflict
+
+	case ErrConditionalRequestConflict:
+		return http.StatusConflict
+
+	case ErrPreconditionFailed:
+		return http.StatusPreconditionFailed
 
 	case ErrBadDigest,
 		ErrIllegalVersioningConfiguration,

--- a/init_test.go
+++ b/init_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"github.com/cevatbarisyilmaz/ara"
 	"io"
 	"io/ioutil"
 	"log"
@@ -31,12 +30,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cevatbarisyilmaz/ara"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 )
@@ -258,12 +260,12 @@ func (ts *testServer) backendObjectExists(bucket, key string) (bool, bool) {
 
 func (ts *testServer) backendPutString(bucket, key string, meta map[string]string, in string) {
 	ts.Helper()
-	ts.OKAll(ts.backend.PutObject(bucket, key, meta, strings.NewReader(in), int64(len(in))))
+	ts.OKAll(ts.backend.PutObject(bucket, key, meta, strings.NewReader(in), int64(len(in)), nil))
 }
 
 func (ts *testServer) backendPutBytes(bucket, key string, meta map[string]string, in []byte) {
 	ts.Helper()
-	ts.OKAll(ts.backend.PutObject(bucket, key, meta, bytes.NewReader(in), int64(len(in))))
+	ts.OKAll(ts.backend.PutObject(bucket, key, meta, bytes.NewReader(in), int64(len(in)), nil))
 }
 
 func (ts *testServer) backendGetString(bucket, key string, rnge *gofakes3.ObjectRangeRequest) string {

--- a/uploader.go
+++ b/uploader.go
@@ -461,7 +461,7 @@ func (u *uploader) CompleteMultipartUpload(bucket, object string, id UploadID, i
 
 	etag = fmt.Sprintf(`"%s-%d"`, hex.EncodeToString(hash.Sum(nil)), len(input.Parts))
 
-	result, err := u.storage.PutObject(bucket, object, mpu.Meta, bytes.NewReader(body), int64(len(body)))
+	result, err := u.storage.PutObject(bucket, object, mpu.Meta, bytes.NewReader(body), int64(len(body)), nil)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
This PR adds support for Conditional Write (IfMatch and IfNoneMatch) on PutObject to all backends (s3mem, s3bolt, s3afero-single and s3afero-multi).

I initially planned on following the precedent set by Conditional Read, which is handled in gofakes3.go generically for all backends. I abandoned this approach though, since currently all backends are responsible for their own locking/atomicity, and establishing an additional locking overlay in gofakes3.go felt too complex. Instead, I settled on ensuring most of the business logic was centralized, but left it to each backend to call as appropriate.

When adding tests, I wanted to ensure all backends worked correctly. I couldn't see an existing pattern for this, so I did something specific to conditional put testing. This (or something similar) would be a nice pattern to apply to all tests though.

Backends are single threaded in gofakes3, so practically ConditionalRequestConflict is never raised.

See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html.