### PR TITLE
For insecure-cors, always return Access-Control-Allow-Origin.

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -64,10 +64,11 @@ func (s *withCORS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Header.Get("Access-Control-Request-Method") != "" &&
 		r.Header.Get("Origin") != ""
 
+	if s.origin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", s.origin)
+	}
+
 	if isPreflight {
-		if s.origin != "" {
-			w.Header().Set("Access-Control-Allow-Origin", s.origin)
-		}
 		if s.methods != "" {
 			w.Header().Set("Access-Control-Allow-Methods", s.methods)
 		}

--- a/cors_test.go
+++ b/cors_test.go
@@ -52,8 +52,8 @@ func TestWrapInsecureCORSGetRequest(t *testing.T) {
 	}
 
 	headers := resp.Header()
-	if _, ok := headers["Access-Control-Allow-Origin"]; ok {
-		t.Errorf("expected no Access-Control-Allow-Origin header")
+	if headers.Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("Expected Access-Control-Allow-Origin: *; got %v", headers.Get("Access-Control-Allow-Origin"))
 	}
 	if _, ok := headers["Access-Control-Allow-Methods"]; ok {
 		t.Errorf("expected no Access-Control-Allow-Methods header")


### PR DESCRIPTION
Per MDN [1], we should always return Access-Control-Allow-Origin, not just on preflight requests.  I have a simple frontend app that gets a presigned S3 URL and then attempts to push a file to S3, but i was getting the following error in my browser console:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://my-bucket.fake-s3.my-org.test/. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing). Status code: 200.
```

Making this change solved the error for me.  Many thanks to @shabbyrobe who coached me through it!

1. https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#simple_requests