### PR TITLE
Fix CopyObject panic when X-Amz-Copy-Source is fully URL-encoded

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -733,12 +733,30 @@ func (g *GoFakeS3) copyObject(bucket, object string, meta map[string]string, w h
 
 	// XXX No support for versionId subresource
 	parts := strings.SplitN(strings.TrimPrefix(source, "/"), "/", 2)
+	sourceDecoded := false
+	if len(parts) < 2 {
+		// The source may be fully URL-encoded (including "/" as "%2F").
+		// Try decoding and splitting again.
+		decoded, err := url.QueryUnescape(source)
+		if err != nil {
+			return err
+		}
+		parts = strings.SplitN(strings.TrimPrefix(decoded, "/"), "/", 2)
+		sourceDecoded = true
+	}
+	if len(parts) < 2 {
+		return ErrorMessage(ErrInvalidArgument, "X-Amz-Copy-Source must contain bucket and key separated by '/'")
+	}
 	srcBucket := parts[0]
 	srcKey := strings.SplitN(parts[1], "?", 2)[0]
 
-	srcKey, err = url.QueryUnescape(srcKey)
-	if err != nil {
-		return err
+	// Only decode the key if we didn't already decode the entire source,
+	// to avoid double-decoding (which corrupts "+" characters).
+	if !sourceDecoded {
+		srcKey, err = url.QueryUnescape(srcKey)
+		if err != nil {
+			return err
+		}
 	}
 	srcObj, err := g.storage.HeadObject(srcBucket, srcKey)
 	if err != nil {
@@ -1218,8 +1236,6 @@ func parsePutConditions(headers http.Header) (*PutConditions, error) {
 		}
 		conditions.IfNoneMatch = &ifNoneMatch
 	}
-
-
 
 	return conditions, nil
 }

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -490,6 +490,77 @@ func TestCopyObjectWithSpecialCharsEscapedInvalied(t *testing.T) {
 	}
 }
 
+func TestCopyObjectFullyEncodedSource(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	srcMeta := map[string]string{
+		"Content-Type": "text/plain",
+	}
+	srcKey := "path/to/source-file.txt"
+	content := "test content"
+	ts.backendPutString(defaultBucket, srcKey, srcMeta, content)
+
+	// Fully encode the source, including "/" as "%2F"
+	copySource := url.QueryEscape(defaultBucket + "/" + srcKey)
+	_, err := svc.CopyObject(t.Context(), &s3.CopyObjectInput{
+		Bucket:     aws.String(defaultBucket),
+		Key:        aws.String("dst-key"),
+		CopySource: aws.String(copySource),
+	})
+	ts.OK(err)
+
+	obj, err := svc.GetObject(t.Context(), &s3.GetObjectInput{
+		Bucket: aws.String(defaultBucket),
+		Key:    aws.String("dst-key"),
+	})
+	ts.OK(err)
+	defer obj.Body.Close()
+
+	objContent, err := io.ReadAll(obj.Body)
+	ts.OK(err)
+	if string(objContent) != content {
+		t.Fatalf("object contents mismatch: got %q, want %q", objContent, content)
+	}
+}
+
+func TestCopyObjectFullyEncodedSourceWithSpecialChars(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	srcMeta := map[string]string{
+		"Content-Type": "text/plain",
+	}
+	srcKey := "file+name with spaces.txt"
+	content := "test content"
+	ts.backendPutString(defaultBucket, srcKey, srcMeta, content)
+
+	// Fully encode the source, including "/" as "%2F"
+	// The "+" becomes "%2B" and space becomes "+"
+	copySource := url.QueryEscape(defaultBucket + "/" + srcKey)
+	_, err := svc.CopyObject(t.Context(), &s3.CopyObjectInput{
+		Bucket:     aws.String(defaultBucket),
+		Key:        aws.String("dst-key"),
+		CopySource: aws.String(copySource),
+	})
+	ts.OK(err)
+
+	obj, err := svc.GetObject(t.Context(), &s3.GetObjectInput{
+		Bucket: aws.String(defaultBucket),
+		Key:    aws.String("dst-key"),
+	})
+	ts.OK(err)
+	defer obj.Body.Close()
+
+	objContent, err := io.ReadAll(obj.Body)
+	ts.OK(err)
+	if string(objContent) != content {
+		t.Fatalf("object contents mismatch: got %q, want %q", objContent, content)
+	}
+}
+
 func TestDeleteBucket(t *testing.T) {
 	t.Run("delete-empty", func(t *testing.T) {
 		ts := newTestServer(t, withoutInitialBuckets())
@@ -1133,7 +1204,7 @@ func TestListBucketPages(t *testing.T) {
 	// Skip all test cases for now as they're failing with SDK v2
 	// The AWS SDK v2 client and the test need to be aligned for correct pagination
 	t.Skip("Skipping TestListBucketPages tests due to incompatibility with AWS SDK v2")
-	
+
 	for idx, tc := range []struct {
 		keys, pageKeys int32
 	}{


### PR DESCRIPTION
CopyObject panics with an index out of range when the X-Amz-Copy-Source header is fully URL-encoded:

```
panic: runtime error: index out of range [1] with length 1
    gofakes3.go:737 (*GoFakeS3).copyObject
```

The S3 API documentation requires the x-amz-copy-source header value to be URL-encoded, but is ambiguous about whether the "/" separating bucket and key should be encoded. Some clients encode only the key (bucket/src%2Bkey) while others encode the entire value, including the separator as "%2F" (bucket%2Fsrc%2Bkey).

gofakes3 only handles the first format, it splits on a literal "/" before URL-decoding, so a fully-encoded value produces a single-element slice, causing the panic.

This PR:
1. Splits the source as-is first (preserves existing behavior)
2. Falls back to URL-decoding and re-splitting if that produced <2 parts
3. Skips the existing per-key url.QueryUnescape when the fallback path ran, to avoid double-decoding — QueryUnescape treats "+" as an encoded space, so decoding twice would corrupt any "+" in the key

Tests added:
- Fully URL-encoded source path (the panic case)
- Fully URL-encoded source with "+" and spaces in the key