### PR TITLE
Include false IsTruncated in ListMultipartUpload(Part)sResult #122

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -392,7 +392,7 @@ type ListMultipartUploadsResult struct {
 	Prefix string `xml:"Prefix,omitempty"`
 
 	CommonPrefixes []CommonPrefix `xml:"CommonPrefixes,omitempty"`
-	IsTruncated    bool           `xml:"IsTruncated,omitempty"`
+	IsTruncated    bool           `xml:"IsTruncated"`
 
 	Uploads []ListMultipartUploadItem `xml:"Upload"`
 }
@@ -418,7 +418,7 @@ type ListMultipartUploadPartsResult struct {
 	PartNumberMarker     int          `xml:"PartNumberMarker"`
 	NextPartNumberMarker int          `xml:"NextPartNumberMarker"`
 	MaxParts             int64        `xml:"MaxParts"`
-	IsTruncated          bool         `xml:"IsTruncated,omitempty"`
+	IsTruncated          bool         `xml:"IsTruncated"`
 
 	Parts []ListMultipartUploadPartItem `xml:"Part"`
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 )
@@ -152,5 +153,22 @@ func TestCopyObjectResult(t *testing.T) {
 	}
 	if string(out) != expected {
 		t.Fatalf("unexpected XML output: %s", string(out))
+	}
+}
+
+func TestMultipartListResultsIncludeIsTruncatedFalse(t *testing.T) {
+	for name, res := range map[string]any{
+		"uploads": ListMultipartUploadsResult{Bucket: "bucket"},
+		"parts":   ListMultipartUploadPartsResult{Bucket: "bucket", Key: "key", UploadID: "upload"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := xml.Marshal(res)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(out), "<IsTruncated>false</IsTruncated>") {
+				t.Fatalf("expected IsTruncated=false in XML: %s", string(out))
+			}
+		})
 	}
 }


### PR DESCRIPTION
[ListMultipartUploadsResult.IsTruncated](https://github.com/johannesboyne/gofakes3/blob/master/messages.go#L395) and [ListMultipartUploadPartsResult.IsTruncated](https://github.com/johannesboyne/gofakes3/blob/master/messages.go#L421) currently has omitempty:

IsTruncated bool `xml:"IsTruncated,omitempty"`
When the value is false, gofakes3 omits false from ListParts responses.

AWS SDK clients that model this field as *bool then parse it as nil. Some clients dereference it because real S3 always includes the field. For example, [Zot Registry](https://zotregistry.dev/latest/)'s S3 storage path via it's upstream [distribution/distribution](https://github.com/distribution/distribution) package can panic during resumable multipart upload handling when it receives a ListParts response without IsTruncated.

Expected response should include the field even when false. This would make ListParts responses closer to S3-compatible behavior and avoid nil-pointer failures in AWS SDK consumers.